### PR TITLE
[M2-D2.2] feat(domain): add StageTransitionService.nextStage()

### DIFF
--- a/src/simulation/domain/stage/stage-transition.ts
+++ b/src/simulation/domain/stage/stage-transition.ts
@@ -1,6 +1,8 @@
 import type { Card } from '../card/card';
 import type { WorkItems, WorkerType } from '../card/work-items';
 import { WorkItems as WorkItemsUtil } from '../card/work-items';
+import type { Stage } from './stage';
+import { Stage as StageFactory } from './stage';
 
 export function canTransition(card: Card): boolean {
   if (card.isBlocked) {
@@ -36,6 +38,29 @@ export function canTransition(card: Card): boolean {
 
     default: {
       const _exhaustive: never = stage;
+      throw new Error(`Unsupported stage: ${_exhaustive}`);
+    }
+  }
+}
+
+export function nextStage(stage: Stage): Stage | null {
+  switch (stage.type) {
+    case 'options':
+      return StageFactory.redActive();
+    case 'red-active':
+      return StageFactory.redFinished();
+    case 'red-finished':
+      return StageFactory.blueActive();
+    case 'blue-active':
+      return StageFactory.blueFinished();
+    case 'blue-finished':
+      return StageFactory.green();
+    case 'green':
+      return StageFactory.done();
+    case 'done':
+      return null;
+    default: {
+      const _exhaustive: never = stage.type;
       throw new Error(`Unsupported stage: ${_exhaustive}`);
     }
   }


### PR DESCRIPTION
## Summary

Implements `nextStage` function in StageTransitionService to return the next stage in the Kanban pipeline sequence.

## Changes

- Add `nextStage(stage: Stage): Stage | null` function to `stage-transition.ts`
- Add comprehensive unit tests covering all stage transitions
- Use exhaustive TypeScript switch for type safety
- Return `null` for terminal done stage
- Follow stage sequence: options→red-active→red-finished→blue-active→blue-finished→green→done

## Test Coverage

- 14 new tests covering all stage transitions
- Parameterized tests using `it.each` for comprehensive coverage
- Edge case testing for terminal state (done → null)

## Implementation Details

- Pure function with no side effects
- Uses Stage factory functions for consistency
- Exhaustive switch statement with TypeScript `never` type checking
- Returns correct next stage or null for done state

Closes #17

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced stage progression functionality for the simulation system, enabling sequential advancement through stages with built-in validation and error handling for unsupported stage types.

* **Tests**
  * Enhanced test coverage for stage transition logic, validating proper control flow and state progression across all stage types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->