### PR TITLE
refactor(components): make Column pure presentational (M8-D8.2)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -313,7 +313,6 @@ function App() {
   // State to track all cards
   const [cards, setCards] = useState<Card[]>(initialCards);
 
-  // Filter cards by stage and convert to domain cards
   const optionsCards = useMemo(
     () => cards.filter(card => card.stage === 'options').map(toDomainCard),
     [cards]

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -4,7 +4,7 @@ import type { WorkItemsType } from './Card';
 import type { Card } from '../simulation/domain/card/card';
 import type { CardId } from '../simulation/domain/card/card-id';
 
-interface WipLimit {
+export interface WipLimit {
   readonly min: number;
   readonly max: number;
 }

--- a/src/components/__tests__/Column.test.tsx
+++ b/src/components/__tests__/Column.test.tsx
@@ -99,7 +99,6 @@ describe('Column Component', () => {
   });
 
   it('accepts wipLimit prop without error', () => {
-    // wipLimit is accepted for future use but not displayed
     render(
       <Column
         title="Red Active"


### PR DESCRIPTION
## Summary
- Column component now accepts domain Card[] instead of CardInput[]
- Removed toDomainCard conversion from Column component (moved to App.tsx)
- Added optional wipLimit prop to Column interface for future WIP limit display
- App.tsx converts cards to domain objects using useMemo + toDomainCard
- Tests updated to use createTestCardWithId from domain test fixtures

This refactoring aligns with the architectural principle of keeping presentational components pure and moving data transformations to the container level.

## Test plan
- [x] All existing Column.test.tsx tests pass
- [x] Added test for wipLimit prop acceptance
- [x] Verified board renders correctly with domain Card objects
- [x] Manual smoke test of card display and interactions

Fixes #34

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary recalculations for card lists to improve render performance.

* **Refactor**
  * Simplified column rendering for clearer domain handling and easier maintenance.

* **New Features**
  * Columns now accept optional WIP limits and block-toggle handling, enabling WIP-aware behavior.

* **Tests**
  * Updated tests and added coverage for WIP limit support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->