### PR TITLE
fix(types): align component types with strict TypeScript build (M9-D9.2)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { useKanbanBoard } from './simulation/api/use-kanban-board';
 import { useSimulationControls } from './simulation/api/use-simulation';
 import { useWorkerManagement } from './simulation/api/use-workers';
 import type { Stage } from './simulation/domain/card/card';
+import type { CardId } from './simulation/domain/card/card-id';
 import { exportBoard, importBoard } from './simulation/infra/json-export';
 
 function AppContent() {
@@ -25,7 +26,7 @@ function AppContent() {
 
   const [activeTab, setActiveTab] = useState<TabType>('kanban');
 
-  const handleCardClick = (cardId: string) => {
+  const handleCardClick = (cardId: CardId) => {
     if (selectedWorkerId) {
       assignWorker(cardId, selectedWorkerId);
       selectWorker(null);
@@ -66,12 +67,21 @@ function AppContent() {
     </div>
   );
 
+  const cardsForDiagrams = board.cards.map(card => ({
+    id: card.id,
+    content: card.content,
+    stage: card.stage,
+    age: card.age,
+    startDay: card.startDay,
+    completionDay: card.completionDay ?? undefined,
+  }));
+
   const renderContent = () => {
     switch (activeTab) {
       case 'kanban': return renderKanbanBoard();
       case 'cfd': return <CumulativeFlowDiagram historicalData={historicalData} />;
-      case 'wip': return <WipAgingDiagram cards={[...board.cards]} currentDay={currentDay} />;
-      case 'metrics': return <FlowMetrics cards={[...board.cards]} currentDay={currentDay} />;
+      case 'wip': return <WipAgingDiagram cards={cardsForDiagrams} currentDay={currentDay} />;
+      case 'metrics': return <FlowMetrics cards={cardsForDiagrams} currentDay={currentDay} />;
     }
   };
 

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Card as CardComponent } from './Card';
 import type { WorkItemsType } from './Card';
-import type { Card } from '../simulation/domain/card/card';
+import type { Card, WorkerType } from '../simulation/domain/card/card';
 import type { CardId } from '../simulation/domain/card/card-id';
 
 export interface WipLimit {
@@ -16,10 +16,10 @@ interface ColumnProps {
   status?: 'active' | 'finished';
   showAddCardButton?: boolean;
   wipLimit?: WipLimit;
-  onCardClick?: (cardId: string) => void;
-  onWorkerDrop?: (cardId: string, workerId: string) => void;
+  onCardClick?: (cardId: CardId) => void;
+  onWorkerDrop?: (cardId: CardId, workerId: string, workerType: WorkerType) => void;
   onAddCard?: () => void;
-  onToggleBlock?: (cardId: string) => void;
+  onToggleBlock?: (cardId: CardId) => void;
 }
 
 export type { WorkItemsType };
@@ -37,17 +37,9 @@ export const Column: React.FC<ColumnProps> = ({
 }) => {
   const stageValue = type === 'options' ? 'options' : `${type}-${status}`;
 
-  const handleCardClick = onCardClick
-    ? (cardId: CardId) => onCardClick(cardId)
-    : undefined;
-
-  const handleWorkerDrop = onWorkerDrop
-    ? (cardId: CardId, workerId: string) => onWorkerDrop(cardId, workerId)
-    : undefined;
-
-  const handleToggleBlock = onToggleBlock
-    ? (cardId: CardId) => onToggleBlock(cardId)
-    : undefined;
+  const handleCardClick = onCardClick;
+  const handleWorkerDrop = onWorkerDrop;
+  const handleToggleBlock = onToggleBlock;
 
   return (
     <div className={`column column-${type} column-${status}`} data-stage={stageValue}>

--- a/src/components/Worker.tsx
+++ b/src/components/Worker.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from 'react';
 
-export type WorkerType = 'red' | 'blue' | 'green' | 'options';
+export type WorkerType = 'red' | 'blue' | 'green';
 
 interface WorkerProps {
   type: WorkerType;

--- a/src/components/WorkerPool.tsx
+++ b/src/components/WorkerPool.tsx
@@ -3,12 +3,12 @@ import { Worker } from './Worker';
 import type { WorkerType } from './Worker';
 
 interface WorkerData {
-  id: string;
-  type: WorkerType;
+  readonly id: string;
+  readonly type: WorkerType;
 }
 
 interface WorkerPoolProps {
-  workers: WorkerData[];
+  workers: readonly WorkerData[];
   selectedWorkerId: string | null;
   onWorkerSelect: (workerId: string) => void;
   onAddWorker?: (type: WorkerType) => void;

--- a/src/components/__tests__/Column.test.tsx
+++ b/src/components/__tests__/Column.test.tsx
@@ -95,7 +95,7 @@ describe('Column Component', () => {
     });
 
     expect(mockOnWorkerDrop).toHaveBeenCalledTimes(1);
-    expect(mockOnWorkerDrop).toHaveBeenCalledWith('A', 'worker-1');
+    expect(mockOnWorkerDrop).toHaveBeenCalledWith('A', 'worker-1', 'red');
   });
 
   it('accepts wipLimit prop without error', () => {


### PR DESCRIPTION
## Summary
- Use CardId branded type consistently in Column and App components
- Add workerType parameter to onWorkerDrop callback for proper type propagation
- Remove 'options' from WorkerType union (UI workers are only red/blue/green)
- Use readonly arrays in WorkerPool props for immutability guarantees
- Map completionDay null to undefined for diagram component compatibility

Fixes type errors found during strict `tsc -b` build verification.

## Test plan
- [x] All 970 tests pass
- [x] `pnpm nx run-many -t lint,typecheck,test` passes
- [x] Build completes without type errors

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)