### PR TITLE
feat(domain): extract Policy strategy interface from runPolicyDay (M1-D1.0)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,8 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  // Generated output — mirrors the build artefacts listed in .gitignore.
+  { ignores: ['dist', 'coverage', 'allure-results', 'allure-report'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,6 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  // Generated output — mirrors the build artefacts listed in .gitignore.
   { ignores: ['dist', 'coverage', 'allure-results', 'allure-report'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -5,7 +5,7 @@ import { SaveIndicator, type SaveStatus } from './SaveIndicator';
 import { ConfirmDialog } from './ConfirmDialog';
 import { SlotManager } from './SlotManager';
 import type { TabType } from './TabNavigation';
-import type { PolicyType } from './PolicyRunner';
+import type { PolicyType } from '../simulation/domain/policy/policy-registry';
 import type { SlotInfo, SlotNumber } from '../simulation/infra/state-repository';
 
 interface NavigationBarProps {

--- a/src/components/PolicyRunner.tsx
+++ b/src/components/PolicyRunner.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { PolicyRegistry } from '../simulation/domain/policy/policy-registry';
 import type { PolicyType } from '../simulation/domain/policy/policy-registry';
 
 interface PolicyRunnerProps {
@@ -38,15 +39,6 @@ export const PolicyRunner: React.FC<PolicyRunnerProps> = ({
   const handleDaysChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = parseInt(e.target.value);
     setDaysToRun(isNaN(value) ? 10 : value);
-  };
-
-  const getPolicyDescription = (policy: PolicyType): string => {
-    switch (policy) {
-      case 'siloted-expert':
-        return 'Workers always work on cards in their own active color (producing 3-6 work items). Finished tasks move to the next column as soon as possible. Max WIP limits are respected at all times.';
-      default:
-        return '';
-    }
   };
 
   const renderProgressBar = () => {
@@ -115,7 +107,7 @@ export const PolicyRunner: React.FC<PolicyRunnerProps> = ({
                 Siloted Expert
               </label>
               <p className="policy-description">
-                {getPolicyDescription(selectedPolicy)}
+                {PolicyRegistry.get(selectedPolicy).description}
               </p>
             </div>
             

--- a/src/components/PolicyRunner.tsx
+++ b/src/components/PolicyRunner.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-
-export type PolicyType = 'siloted-expert';
+import type { PolicyType } from '../simulation/domain/policy/policy-registry';
 
 interface PolicyRunnerProps {
   onRunPolicy: (policyType: PolicyType, days: number) => void;

--- a/src/simulation/application/run-policy.spec.ts
+++ b/src/simulation/application/run-policy.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { WipLimits } from '../domain/wip/wip-limits';
-import { runPolicyDay } from './run-policy';
+import { runPolicyDay, type PolicyType } from './run-policy';
+import type { Card as CardType } from '../domain/card/card';
+import { UnknownPolicyError } from '../domain/policy/unknown-policy-error';
 import { createTestCard, createTestWorker, createValidCardId } from './test-fixtures';
 
 describe('RunPolicyUseCase', () => {
@@ -339,5 +341,87 @@ describe('RunPolicyUseCase', () => {
 
       expect(result.cards[0].stage).toBe('red-active');
     });
+  });
+});
+
+describe('RunPolicyUseCase policy delegation', () => {
+  const neverAssign = (): number => 0.5;
+
+  it('delegates worker assignment to the selected policy', () => {
+    const assignedByPolicy: string[] = [];
+    const recordingPolicy = {
+      id: 'recording',
+      name: 'Recording',
+      description: 'Test double capturing the cards it receives',
+      assignWorkers: (cards: readonly CardType[]): CardType[] => {
+        assignedByPolicy.push(...cards.map((card) => String(card.id)));
+        return [...cards];
+      },
+    };
+
+    runPolicyDay({
+      policy: recordingPolicy,
+      cards: [createTestCard({ id: createValidCardId('A'), stage: 'red-active' })],
+      workers: [createTestWorker('bob', 'red')],
+      currentDay: 0,
+      wipLimits: WipLimits.empty(),
+      random: neverAssign,
+    });
+
+    expect(assignedByPolicy).toEqual(['A']);
+  });
+
+  it('applies the assignment the policy returned', () => {
+    const assigningPolicy = {
+      id: 'assigning',
+      name: 'Assigning',
+      description: 'Test double assigning every worker to every card',
+      assignWorkers: (cards: readonly CardType[]): CardType[] =>
+        cards.map((card) => ({
+          ...card,
+          assignedWorkers: [{ id: 'ghost', type: 'red' as const }],
+        })),
+    };
+
+    const result = runPolicyDay({
+      policy: assigningPolicy,
+      cards: [createTestCard({
+        id: createValidCardId('A'),
+        stage: 'red-active',
+        workItems: { red: { total: 99, completed: 0 }, blue: { total: 5, completed: 0 }, green: { total: 5, completed: 0 } },
+      })],
+      workers: [],
+      currentDay: 0,
+      wipLimits: WipLimits.empty(),
+      random: () => 0.99,
+    });
+
+    expect(result.cards[0].workItems.red.completed).toBeGreaterThan(0);
+  });
+
+  it('resolves a policy given by id', () => {
+    const result = runPolicyDay({
+      policyType: 'siloted-expert',
+      cards: [],
+      workers: [],
+      currentDay: 3,
+      wipLimits: WipLimits.empty(),
+      random: neverAssign,
+    });
+
+    expect(result.newDay).toBe(4);
+  });
+
+  it('rejects an unknown policy id instead of falling back to siloted-expert', () => {
+    expect(() =>
+      runPolicyDay({
+        policyType: 'does-not-exist' as PolicyType,
+        cards: [],
+        workers: [],
+        currentDay: 0,
+        wipLimits: WipLimits.empty(),
+        random: neverAssign,
+      })
+    ).toThrow(UnknownPolicyError);
   });
 });

--- a/src/simulation/application/run-policy.spec.ts
+++ b/src/simulation/application/run-policy.spec.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { WipLimits } from '../domain/wip/wip-limits';
-import { runPolicyDay, type PolicyType } from './run-policy';
+import { runPolicyDay } from './run-policy';
 import type { Card as CardType } from '../domain/card/card';
 import { UnknownPolicyError } from '../domain/policy/unknown-policy-error';
+import type { Policy } from '../domain/policy/policy';
 import { createTestCard, createTestWorker, createValidCardId } from './test-fixtures';
 
 describe('RunPolicyUseCase', () => {
@@ -349,7 +350,7 @@ describe('RunPolicyUseCase policy delegation', () => {
 
   it('delegates worker assignment to the selected policy', () => {
     const assignedByPolicy: string[] = [];
-    const recordingPolicy = {
+    const recordingPolicy: Policy = {
       id: 'recording',
       name: 'Recording',
       description: 'Test double capturing the cards it receives',
@@ -372,7 +373,7 @@ describe('RunPolicyUseCase policy delegation', () => {
   });
 
   it('applies the assignment the policy returned', () => {
-    const assigningPolicy = {
+    const assigningPolicy: Policy = {
       id: 'assigning',
       name: 'Assigning',
       description: 'Test double assigning every worker to every card',
@@ -415,7 +416,8 @@ describe('RunPolicyUseCase policy delegation', () => {
   it('rejects an unknown policy id instead of falling back to siloted-expert', () => {
     expect(() =>
       runPolicyDay({
-        policyType: 'does-not-exist' as PolicyType,
+        // @ts-expect-error an unregistered policy id must not type-check
+        policyType: 'does-not-exist',
         cards: [],
         workers: [],
         currentDay: 0,

--- a/src/simulation/application/run-policy.ts
+++ b/src/simulation/application/run-policy.ts
@@ -28,7 +28,6 @@ interface RunPolicyBaseInput {
   readonly random?: RandomFn;
 }
 
-/** Callers name the strategy by id, or pass one directly (comparison runs, tests). */
 export type RunPolicyInput = RunPolicyBaseInput &
   ({ readonly policyType: PolicyType; readonly policy?: never } | {
     readonly policy: Policy;

--- a/src/simulation/application/run-policy.ts
+++ b/src/simulation/application/run-policy.ts
@@ -15,17 +15,25 @@ import {
   countCardsInStage,
   stageToColumnKey,
 } from './card-stage-helpers';
+import type { Policy } from '../domain/policy/policy';
+import { PolicyRegistry, type PolicyType } from '../domain/policy/policy-registry';
 
-export type PolicyType = 'siloted-expert';
+export type { PolicyType };
 
-export interface RunPolicyInput {
-  readonly policyType: PolicyType;
+interface RunPolicyBaseInput {
   readonly cards: readonly CardType[];
   readonly workers: readonly Worker[];
   readonly currentDay: number;
   readonly wipLimits: ReturnType<typeof WipLimits.empty>;
   readonly random?: RandomFn;
 }
+
+/** Callers name the strategy by id, or pass one directly (comparison runs, tests). */
+export type RunPolicyInput = RunPolicyBaseInput &
+  ({ readonly policyType: PolicyType; readonly policy?: never } | {
+    readonly policy: Policy;
+    readonly policyType?: never;
+  });
 
 export interface RunPolicyResult {
   readonly cards: CardType[];
@@ -166,101 +174,6 @@ function moveToNextStage(
   return updatedCards;
 }
 
-function assignWorkersToMatchingCards(
-  cards: CardType[],
-  workers: readonly Worker[]
-): CardType[] {
-  const emptyWorkers: CardType['assignedWorkers'] = [];
-  let updatedCards = cards.map((card) => ({
-    ...card,
-    assignedWorkers: emptyWorkers,
-  }));
-
-  const redActiveCards = updatedCards
-    .filter((card) => card.stage === 'red-active')
-    .sort((a, b) => b.age - a.age);
-  const blueActiveCards = updatedCards
-    .filter((card) => card.stage === 'blue-active')
-    .sort((a, b) => b.age - a.age);
-  const greenCards = updatedCards
-    .filter((card) => card.stage === 'green')
-    .sort((a, b) => b.age - a.age);
-
-  const redWorkers = workers.filter((w) => w.type === 'red');
-  const blueWorkers = workers.filter((w) => w.type === 'blue');
-  const greenWorkers = workers.filter((w) => w.type === 'green');
-
-  updatedCards = assignWorkersToCards(redWorkers, redActiveCards, updatedCards);
-  updatedCards = assignWorkersToCards(blueWorkers, blueActiveCards, updatedCards);
-  updatedCards = assignWorkersToCards(greenWorkers, greenCards, updatedCards);
-
-  return updatedCards;
-}
-
-function assignWorkersToCards(
-  workersToAssign: readonly Worker[],
-  cardsToAssign: readonly CardType[],
-  allCards: CardType[]
-): CardType[] {
-  if (workersToAssign.length === 0 || cardsToAssign.length === 0) {
-    return allCards;
-  }
-
-  let updatedCards = allCards.map((c) => ({ ...c }));
-  let workerIndex = 0;
-  let cardIndex = 0;
-
-  while (workerIndex < workersToAssign.length && cardIndex < cardsToAssign.length) {
-    const worker = workersToAssign[workerIndex];
-    const targetCardId = cardsToAssign[cardIndex].id;
-
-    updatedCards = updatedCards.map((c) =>
-      c.id === targetCardId
-        ? { ...c, assignedWorkers: [...c.assignedWorkers, { id: worker.id, type: worker.type }] }
-        : c
-    );
-
-    workerIndex++;
-    cardIndex++;
-  }
-
-  if (workerIndex < workersToAssign.length) {
-    cardIndex = 0;
-
-    while (workerIndex < workersToAssign.length) {
-      const worker = workersToAssign[workerIndex];
-      const targetCardId = cardsToAssign[cardIndex].id;
-      const targetCard = updatedCards.find((c) => c.id === targetCardId);
-
-      if (targetCard && targetCard.assignedWorkers.length < 3) {
-        updatedCards = updatedCards.map((c) =>
-          c.id === targetCardId
-            ? { ...c, assignedWorkers: [...c.assignedWorkers, { id: worker.id, type: worker.type }] }
-            : c
-        );
-        workerIndex++;
-      }
-
-      cardIndex++;
-
-      if (cardIndex >= cardsToAssign.length) {
-        const canAnyCardAcceptWorkers = cardsToAssign.some((c) => {
-          const card = updatedCards.find((uc) => uc.id === c.id);
-          return card && card.assignedWorkers.length < 3;
-        });
-
-        if (!canAnyCardAcceptWorkers) {
-          break;
-        }
-
-        cardIndex = 0;
-      }
-    }
-  }
-
-  return updatedCards;
-}
-
 function applyWorkerOutput(cards: CardType[], random: RandomFn): CardType[] {
   return cards.map((card) => applyWorkerOutputToCard(card, random));
 }
@@ -324,6 +237,10 @@ function clearWorkerAssignments(cards: CardType[]): CardType[] {
   return cards.map((card) => ({ ...card, assignedWorkers: [] }));
 }
 
+function resolvePolicy(input: RunPolicyInput): Policy {
+  return input.policy ?? PolicyRegistry.get(input.policyType);
+}
+
 export function runPolicyDay(input: RunPolicyInput): RunPolicyResult {
   const {
     cards,
@@ -333,6 +250,7 @@ export function runPolicyDay(input: RunPolicyInput): RunPolicyResult {
     random = Math.random,
   } = input;
 
+  const policy = resolvePolicy(input);
   const newDay = currentDay + 1;
 
   const cardsAfterOptionsMove = moveOptionsToRedActive(
@@ -346,10 +264,7 @@ export function runPolicyDay(input: RunPolicyInput): RunPolicyResult {
     wipLimits
   );
 
-  const cardsWithWorkers = assignWorkersToMatchingCards(
-    cardsAfterFinishedMove,
-    workers
-  );
+  const cardsWithWorkers = policy.assignWorkers(cardsAfterFinishedMove, workers);
 
   const agedCards = CardAgingService.ageCards(cardsWithWorkers);
 

--- a/src/simulation/domain/policy/index.ts
+++ b/src/simulation/domain/policy/index.ts
@@ -1,0 +1,4 @@
+export type { Policy } from './policy';
+export { SilotedExpertPolicy } from './siloted-expert-policy';
+export { PolicyRegistry, type PolicyType } from './policy-registry';
+export { UnknownPolicyError } from './unknown-policy-error';

--- a/src/simulation/domain/policy/policy-registry.spec.ts
+++ b/src/simulation/domain/policy/policy-registry.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { PolicyRegistry } from './policy-registry';
+import { UnknownPolicyError } from './unknown-policy-error';
+
+describe('PolicyRegistry', () => {
+  describe('looking up a policy', () => {
+    it('returns the siloted-expert policy', () => {
+      const policy = PolicyRegistry.get('siloted-expert');
+
+      expect(policy.id).toBe('siloted-expert');
+    });
+
+    it('exposes a name and a description for the UI', () => {
+      const policy = PolicyRegistry.get('siloted-expert');
+
+      expect(policy.name).toBe('Siloted Expert');
+      expect(policy.description).not.toBe('');
+    });
+
+    it('rejects an unknown policy id instead of falling back silently', () => {
+      expect(() => PolicyRegistry.get('does-not-exist')).toThrow(UnknownPolicyError);
+    });
+
+    it('names the offending policy id on the error', () => {
+      try {
+        PolicyRegistry.get('does-not-exist');
+        expect.unreachable('PolicyRegistry.get should have thrown');
+      } catch (error) {
+        expect(error).toBeInstanceOf(UnknownPolicyError);
+        expect((error as UnknownPolicyError).policyId).toBe('does-not-exist');
+      }
+    });
+
+    it('rejects an empty policy id', () => {
+      expect(() => PolicyRegistry.get('')).toThrow(UnknownPolicyError);
+    });
+  });
+
+  describe('listing policies', () => {
+    it('includes the siloted-expert policy', () => {
+      const ids = PolicyRegistry.list().map((policy) => policy.id);
+
+      expect(ids).toContain('siloted-expert');
+    });
+
+    it('reports every registered policy id as known', () => {
+      const ids = PolicyRegistry.list().map((policy) => policy.id);
+
+      expect(ids.every((id) => PolicyRegistry.isKnown(id))).toBe(true);
+    });
+  });
+
+  describe('checking whether a policy id is known', () => {
+    it('accepts a registered id', () => {
+      expect(PolicyRegistry.isKnown('siloted-expert')).toBe(true);
+    });
+
+    it('rejects an unregistered id', () => {
+      expect(PolicyRegistry.isKnown('does-not-exist')).toBe(false);
+    });
+  });
+});

--- a/src/simulation/domain/policy/policy-registry.ts
+++ b/src/simulation/domain/policy/policy-registry.ts
@@ -2,12 +2,6 @@ import type { Policy } from './policy';
 import { SilotedExpertPolicy } from './siloted-expert-policy';
 import { UnknownPolicyError } from './unknown-policy-error';
 
-/**
- * The single place where a policy becomes available to the simulation.
- *
- * Adding a policy means adding an entry here — neither the RunPolicy use case
- * nor the selection UI needs to change.
- */
 const POLICIES = {
   'siloted-expert': SilotedExpertPolicy,
 } as const satisfies Record<string, Policy>;

--- a/src/simulation/domain/policy/policy-registry.ts
+++ b/src/simulation/domain/policy/policy-registry.ts
@@ -1,0 +1,36 @@
+import type { Policy } from './policy';
+import { SilotedExpertPolicy } from './siloted-expert-policy';
+import { UnknownPolicyError } from './unknown-policy-error';
+
+/**
+ * The single place where a policy becomes available to the simulation.
+ *
+ * Adding a policy means adding an entry here — neither the RunPolicy use case
+ * nor the selection UI needs to change.
+ */
+const POLICIES = {
+  'siloted-expert': SilotedExpertPolicy,
+} as const satisfies Record<string, Policy>;
+
+export type PolicyType = keyof typeof POLICIES;
+
+function isRegistered(id: string): id is PolicyType {
+  return Object.prototype.hasOwnProperty.call(POLICIES, id);
+}
+
+export const PolicyRegistry = {
+  get(id: string): Policy {
+    if (!isRegistered(id)) {
+      throw new UnknownPolicyError(id);
+    }
+    return POLICIES[id];
+  },
+
+  isKnown(id: string): id is PolicyType {
+    return isRegistered(id);
+  },
+
+  list(): readonly Policy[] {
+    return Object.values(POLICIES);
+  },
+};

--- a/src/simulation/domain/policy/policy.ts
+++ b/src/simulation/domain/policy/policy.ts
@@ -1,13 +1,6 @@
 import type { Card } from '../card/card';
 import type { Worker } from '../worker/worker';
 
-/**
- * The part of a simulation policy that varies between strategies.
- *
- * The day pipeline (pull, age, apply output, transition) is shared and lives in
- * the RunPolicy use case; only the decision of which worker works on which card
- * belongs here.
- */
 export interface Policy {
   readonly id: string;
   readonly name: string;

--- a/src/simulation/domain/policy/policy.ts
+++ b/src/simulation/domain/policy/policy.ts
@@ -1,0 +1,17 @@
+import type { Card } from '../card/card';
+import type { Worker } from '../worker/worker';
+
+/**
+ * The part of a simulation policy that varies between strategies.
+ *
+ * The day pipeline (pull, age, apply output, transition) is shared and lives in
+ * the RunPolicy use case; only the decision of which worker works on which card
+ * belongs here.
+ */
+export interface Policy {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+
+  assignWorkers(cards: readonly Card[], workers: readonly Worker[]): Card[];
+}

--- a/src/simulation/domain/policy/siloted-expert-policy.spec.ts
+++ b/src/simulation/domain/policy/siloted-expert-policy.spec.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { SilotedExpertPolicy } from './siloted-expert-policy';
+import {
+  createTestCardWithId,
+  createValidCardId,
+} from '../card/card-test-fixtures';
+import { Worker } from '../worker/worker';
+import type { Card } from '../card/card';
+
+function assignedIdsOf(cards: readonly Card[], cardId: string): string[] {
+  const id = createValidCardId(cardId);
+  const card = cards.find((candidate) => candidate.id === id);
+  if (!card) throw new Error(`Card ${cardId} not found`);
+  return card.assignedWorkers.map((worker) => worker.id);
+}
+
+describe('SilotedExpertPolicy', () => {
+  describe('matching workers to their own colour', () => {
+    it('assigns a red worker to a red-active card', () => {
+      const cards = [createTestCardWithId('A', { stage: 'red-active' })];
+      const workers = [Worker.create('bob', 'red')];
+
+      const result = SilotedExpertPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual(['bob']);
+    });
+
+    it('leaves a red worker unassigned when only blue work is available', () => {
+      const cards = [createTestCardWithId('A', { stage: 'blue-active' })];
+      const workers = [Worker.create('bob', 'red')];
+
+      const result = SilotedExpertPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+
+    it('assigns a green worker to a green card', () => {
+      const cards = [createTestCardWithId('A', { stage: 'green' })];
+      const workers = [Worker.create('taz', 'green')];
+
+      const result = SilotedExpertPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual(['taz']);
+    });
+
+    it('ignores cards that are not in an active stage', () => {
+      const cards = [createTestCardWithId('A', { stage: 'red-finished' })];
+      const workers = [Worker.create('bob', 'red')];
+
+      const result = SilotedExpertPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+  });
+
+  describe('ordering cards by age', () => {
+    it('gives the single worker to the oldest card', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'red-active', age: 1 }),
+        createTestCardWithId('B', { stage: 'red-active', age: 7 }),
+      ];
+      const workers = [Worker.create('bob', 'red')];
+
+      const result = SilotedExpertPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'B')).toEqual(['bob']);
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+
+    it('spreads workers one per card before doubling up', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'red-active', age: 5 }),
+        createTestCardWithId('B', { stage: 'red-active', age: 3 }),
+      ];
+      const workers = [Worker.create('bob', 'red'), Worker.create('amy', 'red')];
+
+      const result = SilotedExpertPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual(['bob']);
+      expect(assignedIdsOf(result, 'B')).toEqual(['amy']);
+    });
+  });
+
+  describe('respecting the three-worker ceiling per card', () => {
+    it('stacks at most three workers on a single card', () => {
+      const cards = [createTestCardWithId('A', { stage: 'red-active' })];
+      const workers = [
+        Worker.create('bob', 'red'),
+        Worker.create('amy', 'red'),
+        Worker.create('joe', 'red'),
+        Worker.create('sue', 'red'),
+      ];
+
+      const result = SilotedExpertPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual(['bob', 'amy', 'joe']);
+    });
+  });
+
+  describe('handling empty inputs', () => {
+    it('returns an empty board untouched', () => {
+      const result = SilotedExpertPolicy.assignWorkers([], [Worker.create('bob', 'red')]);
+
+      expect(result).toEqual([]);
+    });
+
+    it('clears previous assignments when no worker is available', () => {
+      const cards = [
+        createTestCardWithId('A', {
+          stage: 'red-active',
+          assignedWorkers: [{ id: 'stale', type: 'red' }],
+        }),
+      ];
+
+      const result = SilotedExpertPolicy.assignWorkers(cards, []);
+
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+  });
+
+  describe('preserving immutability', () => {
+    it('leaves the cards it was given unchanged', () => {
+      const cards = [createTestCardWithId('A', { stage: 'red-active' })];
+      const workers = [Worker.create('bob', 'red')];
+
+      SilotedExpertPolicy.assignWorkers(cards, workers);
+
+      expect(cards[0].assignedWorkers).toEqual([]);
+    });
+  });
+
+  describe('describing itself', () => {
+    it('is identified as siloted-expert', () => {
+      expect(SilotedExpertPolicy.id).toBe('siloted-expert');
+    });
+  });
+});

--- a/src/simulation/domain/policy/siloted-expert-policy.ts
+++ b/src/simulation/domain/policy/siloted-expert-policy.ts
@@ -11,12 +11,7 @@ function cardsInStage(cards: readonly Card[], stage: Card['stage']): Card[] {
   return cards.filter((card) => card.stage === stage).sort(byAgeDescending);
 }
 
-/**
- * Hands the workers out one per card in order, then keeps cycling over the same
- * cards — round-robin, not fill-the-first — until every worker is placed or no
- * card has room left.
- */
-function shareOutWorkers(
+function shareWorkersRoundRobin(
   workersToAssign: readonly Worker[],
   cardCount: number
 ): Worker[][] {
@@ -66,7 +61,10 @@ function assignWorkersToCards(
     return allCards;
   }
 
-  const assignmentsPerCard = shareOutWorkers(workersToAssign, cardsToAssign.length);
+  const assignmentsPerCard = shareWorkersRoundRobin(
+    workersToAssign,
+    cardsToAssign.length
+  );
 
   const assignmentsByCardId = new Map(
     cardsToAssign.map((card, index) => [card.id, assignmentsPerCard[index]])

--- a/src/simulation/domain/policy/siloted-expert-policy.ts
+++ b/src/simulation/domain/policy/siloted-expert-policy.ts
@@ -1,0 +1,117 @@
+import type { Card } from '../card/card';
+import { MAX_ASSIGNED_WORKERS } from '../card/card';
+import type { Worker } from '../worker/worker';
+import type { Policy } from './policy';
+
+function byAgeDescending(first: Card, second: Card): number {
+  return second.age - first.age;
+}
+
+function cardsInStage(cards: readonly Card[], stage: Card['stage']): Card[] {
+  return cards.filter((card) => card.stage === stage).sort(byAgeDescending);
+}
+
+/**
+ * Hands the workers out one per card in order, then keeps cycling over the same
+ * cards — round-robin, not fill-the-first — until every worker is placed or no
+ * card has room left.
+ */
+function shareOutWorkers(
+  workersToAssign: readonly Worker[],
+  cardCount: number
+): Worker[][] {
+  const assignmentsPerCard: Worker[][] = Array.from({ length: cardCount }, () => []);
+
+  let workerIndex = 0;
+  let cardIndex = 0;
+
+  while (workerIndex < workersToAssign.length && cardIndex < cardCount) {
+    assignmentsPerCard[cardIndex].push(workersToAssign[workerIndex]);
+    workerIndex++;
+    cardIndex++;
+  }
+
+  cardIndex = 0;
+
+  while (workerIndex < workersToAssign.length) {
+    if (assignmentsPerCard[cardIndex].length < MAX_ASSIGNED_WORKERS) {
+      assignmentsPerCard[cardIndex].push(workersToAssign[workerIndex]);
+      workerIndex++;
+    }
+
+    cardIndex++;
+
+    if (cardIndex >= cardCount) {
+      const anyCardHasRoom = assignmentsPerCard.some(
+        (assignments) => assignments.length < MAX_ASSIGNED_WORKERS
+      );
+
+      if (!anyCardHasRoom) {
+        break;
+      }
+
+      cardIndex = 0;
+    }
+  }
+
+  return assignmentsPerCard;
+}
+
+function assignWorkersToCards(
+  workersToAssign: readonly Worker[],
+  cardsToAssign: readonly Card[],
+  allCards: Card[]
+): Card[] {
+  if (workersToAssign.length === 0 || cardsToAssign.length === 0) {
+    return allCards;
+  }
+
+  const assignmentsPerCard = shareOutWorkers(workersToAssign, cardsToAssign.length);
+
+  const assignmentsByCardId = new Map(
+    cardsToAssign.map((card, index) => [card.id, assignmentsPerCard[index]])
+  );
+
+  return allCards.map((card) => {
+    const assignments = assignmentsByCardId.get(card.id);
+    if (assignments === undefined || assignments.length === 0) {
+      return card;
+    }
+
+    return {
+      ...card,
+      assignedWorkers: [
+        ...card.assignedWorkers,
+        ...assignments.map((worker) => ({ id: worker.id, type: worker.type })),
+      ],
+    };
+  });
+}
+
+const DESCRIPTION =
+  'Each worker only works on cards matching their own colour, oldest cards first.';
+
+export const SilotedExpertPolicy: Policy = {
+  id: 'siloted-expert',
+  name: 'Siloted Expert',
+  description: DESCRIPTION,
+
+  assignWorkers(cards: readonly Card[], workers: readonly Worker[]): Card[] {
+    const noWorkers: Card['assignedWorkers'] = [];
+    let updatedCards = cards.map((card) => ({ ...card, assignedWorkers: noWorkers }));
+
+    const redActiveCards = cardsInStage(updatedCards, 'red-active');
+    const blueActiveCards = cardsInStage(updatedCards, 'blue-active');
+    const greenCards = cardsInStage(updatedCards, 'green');
+
+    const redWorkers = workers.filter((worker) => worker.type === 'red');
+    const blueWorkers = workers.filter((worker) => worker.type === 'blue');
+    const greenWorkers = workers.filter((worker) => worker.type === 'green');
+
+    updatedCards = assignWorkersToCards(redWorkers, redActiveCards, updatedCards);
+    updatedCards = assignWorkersToCards(blueWorkers, blueActiveCards, updatedCards);
+    updatedCards = assignWorkersToCards(greenWorkers, greenCards, updatedCards);
+
+    return updatedCards;
+  },
+};

--- a/src/simulation/domain/policy/siloted-expert-policy.ts
+++ b/src/simulation/domain/policy/siloted-expert-policy.ts
@@ -1,6 +1,7 @@
 import type { Card } from '../card/card';
 import { MAX_ASSIGNED_WORKERS } from '../card/card';
 import type { Worker } from '../worker/worker';
+import type { WorkerType } from '../worker/worker-type';
 import type { Policy } from './policy';
 
 function byAgeDescending(first: Card, second: Card): number {
@@ -87,7 +88,20 @@ function assignWorkersToCards(
 }
 
 const DESCRIPTION =
-  'Each worker only works on cards matching their own colour, oldest cards first.';
+  'Workers always work on cards in their own active color (producing 3-6 work items). ' +
+  'Finished tasks move to the next column as soon as possible. ' +
+  'Max WIP limits are respected at all times.';
+
+interface WorkLane {
+  readonly stage: Card['stage'];
+  readonly workerType: WorkerType;
+}
+
+const LANES: readonly WorkLane[] = [
+  { stage: 'red-active', workerType: 'red' },
+  { stage: 'blue-active', workerType: 'blue' },
+  { stage: 'green', workerType: 'green' },
+];
 
 export const SilotedExpertPolicy: Policy = {
   id: 'siloted-expert',
@@ -96,20 +110,19 @@ export const SilotedExpertPolicy: Policy = {
 
   assignWorkers(cards: readonly Card[], workers: readonly Worker[]): Card[] {
     const noWorkers: Card['assignedWorkers'] = [];
-    let updatedCards = cards.map((card) => ({ ...card, assignedWorkers: noWorkers }));
+    const unassignedCards = cards.map((card) => ({
+      ...card,
+      assignedWorkers: noWorkers,
+    }));
 
-    const redActiveCards = cardsInStage(updatedCards, 'red-active');
-    const blueActiveCards = cardsInStage(updatedCards, 'blue-active');
-    const greenCards = cardsInStage(updatedCards, 'green');
-
-    const redWorkers = workers.filter((worker) => worker.type === 'red');
-    const blueWorkers = workers.filter((worker) => worker.type === 'blue');
-    const greenWorkers = workers.filter((worker) => worker.type === 'green');
-
-    updatedCards = assignWorkersToCards(redWorkers, redActiveCards, updatedCards);
-    updatedCards = assignWorkersToCards(blueWorkers, blueActiveCards, updatedCards);
-    updatedCards = assignWorkersToCards(greenWorkers, greenCards, updatedCards);
-
-    return updatedCards;
+    return LANES.reduce(
+      (assignedCards, lane) =>
+        assignWorkersToCards(
+          workers.filter((worker) => worker.type === lane.workerType),
+          cardsInStage(assignedCards, lane.stage),
+          assignedCards
+        ),
+      unassignedCards
+    );
   },
 };

--- a/src/simulation/domain/policy/unknown-policy-error.ts
+++ b/src/simulation/domain/policy/unknown-policy-error.ts
@@ -1,0 +1,10 @@
+export class UnknownPolicyError extends Error {
+  readonly code = 'UNKNOWN_POLICY' as const;
+  readonly policyId: string;
+
+  constructor(policyId: string) {
+    super(`Unknown policy '${policyId}'`);
+    this.name = 'UnknownPolicyError';
+    this.policyId = policyId;
+  }
+}


### PR DESCRIPTION
Closes #103

## Deliverable

Le pipeline de simulation d'une journée est désormais indépendant de la stratégie d'affectation : ajouter une politique ne demande plus de le dupliquer.

Closes #103

## Problème

`runPolicyDay` (367 lignes) mélangeait deux responsabilités : l'orchestration de la journée (déplacer, vieillir, produire, transitionner) et la stratégie siloted-expert (quel worker sur quelle carte). `PolicyType` était l'union à un seul membre `'siloted-expert'`.

Sans cette extraction, les politiques D1.1 à D1.4 auraient chacune recopié les 7 étapes du pipeline.

## Solution

| Fichier | Rôle |
|---|---|
| `domain/policy/policy.ts` | Interface `Policy` — uniquement la partie variable (`assignWorkers`) |
| `domain/policy/siloted-expert-policy.ts` | Le comportement existant, isolé dans le domaine |
| `domain/policy/policy-registry.ts` | Registre unique ; `PolicyType` en dérive |
| `domain/policy/unknown-policy-error.ts` | Erreur typée, fail-fast sur id inconnu |
| `application/run-policy.ts` | 367 → 280 lignes, délègue l'affectation |

`RunPolicyInput` accepte soit un `policyType`, soit une `Policy` directe (union discriminée : les deux à la fois est impossible à écrire). Le mode comparaison du M2 devra exécuter des politiques en parallèle sans passer par le registre, et cela rend le pipeline testable par double.

## Comportement inchangé

`src/__golden-master__/policy-execution.golden.spec.ts` et son snapshot **ne sont pas modifiés** et restent verts — c'est le filet de sécurité exigé par le ticket.

Point de vigilance pour la relecture : la boucle d'affectation a été réécrite (elle re-mappait toutes les cartes à chaque worker et portait une branche morte — `targetCard` toujours trouvé par construction). Le partage **round-robin** est préservé à l'identique ; une implémentation « remplir la première carte jusqu'à 3 » aurait été une régression silencieuse. Couverture de branches à 100 % sur le module.

## Hors périmètre strict du ticket

Deux corrections incluses, en commits séparés pour rester dissociables :

- `fdb9736` — `eslint.config.js` n'ignorait que `dist`. Après un `--coverage` local, 6 faux warnings apparaissaient sur les fichiers générés. Ajout de `coverage/`, `allure-results/`, `allure-report/`, cohérent avec `.gitignore`. La CI n'était pas affectée.
- `2f27857` — `PolicyRunner.tsx` déclarait son propre `PolicyType` en double du registre ; le composant et `NavigationBar` importent maintenant le type du domaine.

## Vérification

```bash
npm run lint    # 0 erreur, 0 warning
npm run build   # tsc -b + vite build OK
npm run test:run # 1374 tests, +24
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a policy registry with policy lookup, listing, and validation.
  * Added support for selecting a registered policy or providing a custom policy when running simulations.
  * Added worker assignment using the Siloted Expert policy, including color and stage matching, age ordering, and assignment limits.
  * Added clear errors for unknown policy identifiers.

* **Bug Fixes**
  * Improved policy delegation and worker assignment consistency.

* **Tests**
  * Added comprehensive coverage for policy behavior, registration, delegation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->