### PR TITLE
feat(domain): add Generalist policy assigning workers regardless of colour (M1-D1.1)

### DIFF
--- a/src/simulation/application/card-stage-helpers.ts
+++ b/src/simulation/application/card-stage-helpers.ts
@@ -1,7 +1,9 @@
 import type { Card as CardType } from '../domain/card/card';
 import {
   WorkerOutputCalculator,
+  standardOutputRange,
   type ColumnColor,
+  type OutputRangeFor,
   type RandomFn,
 } from '../domain/worker/worker-output';
 import type { ColumnKey } from '../domain/wip/wip-limits';
@@ -44,7 +46,8 @@ export function countCardsInStage(
 
 export function applyWorkerOutputToCard(
   card: CardType,
-  random: RandomFn
+  random: RandomFn,
+  outputRangeFor: OutputRangeFor = standardOutputRange
 ): CardType {
   if (card.assignedWorkers.length === 0 || !isActiveStage(card.stage)) {
     return card;
@@ -54,9 +57,8 @@ export function applyWorkerOutputToCard(
   let workItems = { ...card.workItems };
 
   for (const worker of card.assignedWorkers) {
-    const output = WorkerOutputCalculator.calculate(
-      worker.type,
-      columnColor,
+    const output = WorkerOutputCalculator.calculateInRange(
+      outputRangeFor(worker.type, columnColor),
       random
     );
 

--- a/src/simulation/application/run-policy.spec.ts
+++ b/src/simulation/application/run-policy.spec.ts
@@ -358,6 +358,7 @@ describe('RunPolicyUseCase policy delegation', () => {
         assignedByPolicy.push(...cards.map((card) => String(card.id)));
         return [...cards];
       },
+      outputRangeFor: () => ({ min: 0, max: 3 }),
     };
 
     runPolicyDay({
@@ -382,6 +383,7 @@ describe('RunPolicyUseCase policy delegation', () => {
           ...card,
           assignedWorkers: [{ id: 'ghost', type: 'red' as const }],
         })),
+      outputRangeFor: () => ({ min: 0, max: 3 }),
     };
 
     const result = runPolicyDay({
@@ -425,5 +427,60 @@ describe('RunPolicyUseCase policy delegation', () => {
         random: neverAssign,
       })
     ).toThrow(UnknownPolicyError);
+  });
+});
+
+describe('RunPolicyUseCase output range delegation', () => {
+  const alwaysMaxOutput = (): number => 0.99;
+
+  it('caps a matching worker at the generalist range', () => {
+    const result = runPolicyDay({
+      policyType: 'generalist',
+      cards: [createTestCard({
+        id: createValidCardId('A'),
+        stage: 'red-active',
+        workItems: { red: { total: 99, completed: 0 }, blue: { total: 5, completed: 0 }, green: { total: 5, completed: 0 } },
+      })],
+      workers: [createTestWorker('bob', 'red')],
+      currentDay: 0,
+      wipLimits: WipLimits.empty(),
+      random: alwaysMaxOutput,
+    });
+
+    expect(result.cards[0].workItems.red.completed).toBe(3);
+  });
+
+  it('grants the specialisation bonus under siloted-expert', () => {
+    const result = runPolicyDay({
+      policyType: 'siloted-expert',
+      cards: [createTestCard({
+        id: createValidCardId('A'),
+        stage: 'red-active',
+        workItems: { red: { total: 99, completed: 0 }, blue: { total: 5, completed: 0 }, green: { total: 5, completed: 0 } },
+      })],
+      workers: [createTestWorker('bob', 'red')],
+      currentDay: 0,
+      wipLimits: WipLimits.empty(),
+      random: alwaysMaxOutput,
+    });
+
+    expect(result.cards[0].workItems.red.completed).toBe(6);
+  });
+
+  it('lets a generalist work on a card outside their colour', () => {
+    const result = runPolicyDay({
+      policyType: 'generalist',
+      cards: [createTestCard({
+        id: createValidCardId('A'),
+        stage: 'blue-active',
+        workItems: { red: { total: 5, completed: 5 }, blue: { total: 99, completed: 0 }, green: { total: 5, completed: 0 } },
+      })],
+      workers: [createTestWorker('bob', 'red')],
+      currentDay: 0,
+      wipLimits: WipLimits.empty(),
+      random: alwaysMaxOutput,
+    });
+
+    expect(result.cards[0].workItems.blue.completed).toBe(3);
   });
 });

--- a/src/simulation/application/run-policy.ts
+++ b/src/simulation/application/run-policy.ts
@@ -173,8 +173,14 @@ function moveToNextStage(
   return updatedCards;
 }
 
-function applyWorkerOutput(cards: CardType[], random: RandomFn): CardType[] {
-  return cards.map((card) => applyWorkerOutputToCard(card, random));
+function applyWorkerOutput(
+  cards: CardType[],
+  random: RandomFn,
+  policy: Policy
+): CardType[] {
+  return cards.map((card) =>
+    applyWorkerOutputToCard(card, random, policy.outputRangeFor)
+  );
 }
 
 function transitionReadyCards(
@@ -267,7 +273,7 @@ export function runPolicyDay(input: RunPolicyInput): RunPolicyResult {
 
   const agedCards = CardAgingService.ageCards(cardsWithWorkers);
 
-  const cardsWithOutput = applyWorkerOutput(agedCards, random);
+  const cardsWithOutput = applyWorkerOutput(agedCards, random, policy);
 
   const transitionedCards = transitionReadyCards(
     cardsWithOutput,

--- a/src/simulation/domain/policy/generalist-policy.spec.ts
+++ b/src/simulation/domain/policy/generalist-policy.spec.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import { GeneralistPolicy } from './generalist-policy';
+import {
+  createTestCardWithId,
+  createValidCardId,
+} from '../card/card-test-fixtures';
+import { Worker } from '../worker/worker';
+import type { Card } from '../card/card';
+import type { WorkItems } from '../card/work-items';
+
+function assignedIdsOf(cards: readonly Card[], cardId: string): string[] {
+  const id = createValidCardId(cardId);
+  const card = cards.find((candidate) => candidate.id === id);
+  if (!card) throw new Error(`Card ${cardId} not found`);
+  return card.assignedWorkers.map((worker) => worker.id);
+}
+
+function workItemsWithRedRemaining(remaining: number): WorkItems {
+  return {
+    red: { total: 10, completed: 10 - remaining },
+    blue: { total: 10, completed: 0 },
+    green: { total: 10, completed: 0 },
+  };
+}
+
+describe('GeneralistPolicy', () => {
+  describe('ignoring worker colour', () => {
+    it('assigns a red worker to a blue-active card', () => {
+      const cards = [createTestCardWithId('A', { stage: 'blue-active' })];
+      const workers = [Worker.create('bob', 'red')];
+
+      const result = GeneralistPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual(['bob']);
+    });
+
+    it('assigns a green worker to a red-active card', () => {
+      const cards = [createTestCardWithId('A', { stage: 'red-active' })];
+      const workers = [Worker.create('taz', 'green')];
+
+      const result = GeneralistPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual(['taz']);
+    });
+
+    it('ignores cards that are not in an active stage', () => {
+      const cards = [createTestCardWithId('A', { stage: 'red-finished' })];
+      const workers = [Worker.create('bob', 'red')];
+
+      const result = GeneralistPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+
+    it('leaves cards waiting in options untouched', () => {
+      const cards = [createTestCardWithId('A', { stage: 'options' })];
+      const workers = [Worker.create('bob', 'red')];
+
+      const result = GeneralistPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+  });
+
+  describe('prioritising the oldest work', () => {
+    it('gives the single worker to the oldest card across colours', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'red-active', age: 2 }),
+        createTestCardWithId('B', { stage: 'green', age: 9 }),
+      ];
+      const workers = [Worker.create('bob', 'red')];
+
+      const result = GeneralistPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'B')).toEqual(['bob']);
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+
+    it('breaks an age tie by favouring the card closest to completion', () => {
+      const cards = [
+        createTestCardWithId('A', {
+          stage: 'red-active',
+          age: 5,
+          workItems: workItemsWithRedRemaining(8),
+        }),
+        createTestCardWithId('B', {
+          stage: 'red-active',
+          age: 5,
+          workItems: workItemsWithRedRemaining(2),
+        }),
+      ];
+      const workers = [Worker.create('bob', 'red')];
+
+      const result = GeneralistPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'B')).toEqual(['bob']);
+    });
+
+    it('breaks a full tie by card id so runs stay reproducible', () => {
+      const cards = [
+        createTestCardWithId('B', { stage: 'red-active', age: 5 }),
+        createTestCardWithId('A', { stage: 'red-active', age: 5 }),
+      ];
+      const workers = [Worker.create('bob', 'red')];
+
+      const result = GeneralistPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual(['bob']);
+    });
+  });
+
+  describe('skipping blocked cards', () => {
+    it('assigns no worker to a blocked card', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'red-active', isBlocked: true }),
+      ];
+      const workers = [Worker.create('bob', 'red')];
+
+      const result = GeneralistPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+
+    it('sends the worker to an unblocked younger card instead', () => {
+      const cards = [
+        createTestCardWithId('A', {
+          stage: 'red-active',
+          age: 9,
+          isBlocked: true,
+        }),
+        createTestCardWithId('B', { stage: 'blue-active', age: 1 }),
+      ];
+      const workers = [Worker.create('bob', 'red')];
+
+      const result = GeneralistPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'B')).toEqual(['bob']);
+    });
+  });
+
+  describe('respecting the three-worker ceiling', () => {
+    it('stacks at most three workers on a single card', () => {
+      const cards = [createTestCardWithId('A', { stage: 'red-active' })];
+      const workers = [
+        Worker.create('bob', 'red'),
+        Worker.create('amy', 'blue'),
+        Worker.create('joe', 'green'),
+        Worker.create('sue', 'red'),
+      ];
+
+      const result = GeneralistPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual(['bob', 'amy', 'joe']);
+    });
+
+    it('spreads workers one per card before doubling up', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'red-active', age: 5 }),
+        createTestCardWithId('B', { stage: 'green', age: 3 }),
+      ];
+      const workers = [Worker.create('bob', 'red'), Worker.create('amy', 'blue')];
+
+      const result = GeneralistPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual(['bob']);
+      expect(assignedIdsOf(result, 'B')).toEqual(['amy']);
+    });
+  });
+
+  describe('producing without a specialisation bonus', () => {
+    it('caps a matching worker at the generalist range', () => {
+      expect(GeneralistPolicy.outputRangeFor('red', 'red')).toEqual({ min: 0, max: 3 });
+    });
+
+    it('uses the same range for a mismatched worker', () => {
+      expect(GeneralistPolicy.outputRangeFor('red', 'green')).toEqual({ min: 0, max: 3 });
+    });
+  });
+
+  describe('handling empty inputs', () => {
+    it('returns an empty board untouched', () => {
+      const result = GeneralistPolicy.assignWorkers([], [Worker.create('bob', 'red')]);
+
+      expect(result).toEqual([]);
+    });
+
+    it('clears previous assignments when no worker is available', () => {
+      const cards = [
+        createTestCardWithId('A', {
+          stage: 'red-active',
+          assignedWorkers: [{ id: 'stale', type: 'red' }],
+        }),
+      ];
+
+      const result = GeneralistPolicy.assignWorkers(cards, []);
+
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+  });
+
+  describe('describing itself', () => {
+    it('is registered as generalist', () => {
+      expect(GeneralistPolicy.id).toBe('generalist');
+    });
+  });
+});

--- a/src/simulation/domain/policy/generalist-policy.ts
+++ b/src/simulation/domain/policy/generalist-policy.ts
@@ -6,7 +6,7 @@ import {
   type OutputRange,
 } from '../worker/worker-output';
 import type { Policy } from './policy';
-import { assignWorkersToCards } from './worker-sharing';
+import { assignWorkersToCards, withoutAssignments } from './worker-sharing';
 
 const DESCRIPTION =
   'Workers take on any card needing work regardless of colour (producing 0-3 work items). ' +
@@ -52,11 +52,7 @@ export const GeneralistPolicy: Policy = {
   description: DESCRIPTION,
 
   assignWorkers(cards: readonly Card[], workers: readonly Worker[]): Card[] {
-    const noWorkers: Card['assignedWorkers'] = [];
-    const unassignedCards = cards.map((card) => ({
-      ...card,
-      assignedWorkers: noWorkers,
-    }));
+    const unassignedCards = withoutAssignments(cards);
 
     const cardsNeedingWork = unassignedCards
       .filter(isAvailableForWork)

--- a/src/simulation/domain/policy/generalist-policy.ts
+++ b/src/simulation/domain/policy/generalist-policy.ts
@@ -1,0 +1,71 @@
+import type { Card } from '../card/card';
+import type { Worker } from '../worker/worker';
+import {
+  NON_SPECIALIZED_RANGE,
+  type ColumnColor,
+  type OutputRange,
+} from '../worker/worker-output';
+import type { Policy } from './policy';
+import { assignWorkersToCards } from './worker-sharing';
+
+const DESCRIPTION =
+  'Workers take on any card needing work regardless of colour (producing 0-3 work items). ' +
+  'The oldest cards are served first, then the ones closest to completion.';
+
+const ACTIVE_STAGES: readonly Card['stage'][] = [
+  'red-active',
+  'blue-active',
+  'green',
+];
+
+function colorOfStage(stage: Card['stage']): ColumnColor {
+  if (stage === 'red-active') return 'red';
+  if (stage === 'blue-active') return 'blue';
+  return 'green';
+}
+
+function remainingWorkOn(card: Card): number {
+  const progress = card.workItems[colorOfStage(card.stage)];
+  return progress.total - progress.completed;
+}
+
+function isAvailableForWork(card: Card): boolean {
+  return !card.isBlocked && ACTIVE_STAGES.includes(card.stage);
+}
+
+function byOldestThenClosestToCompletion(first: Card, second: Card): number {
+  if (first.age !== second.age) {
+    return second.age - first.age;
+  }
+
+  const remainingDifference = remainingWorkOn(first) - remainingWorkOn(second);
+  if (remainingDifference !== 0) {
+    return remainingDifference;
+  }
+
+  return first.id.localeCompare(second.id);
+}
+
+export const GeneralistPolicy: Policy = {
+  id: 'generalist',
+  name: 'Generalist',
+  description: DESCRIPTION,
+
+  assignWorkers(cards: readonly Card[], workers: readonly Worker[]): Card[] {
+    const noWorkers: Card['assignedWorkers'] = [];
+    const unassignedCards = cards.map((card) => ({
+      ...card,
+      assignedWorkers: noWorkers,
+    }));
+
+    const cardsNeedingWork = unassignedCards
+      .filter(isAvailableForWork)
+      .sort(byOldestThenClosestToCompletion);
+
+    return assignWorkersToCards(workers, cardsNeedingWork, unassignedCards);
+  },
+
+  outputRangeFor(): OutputRange {
+    return NON_SPECIALIZED_RANGE;
+  },
+};

--- a/src/simulation/domain/policy/index.ts
+++ b/src/simulation/domain/policy/index.ts
@@ -1,4 +1,5 @@
 export type { Policy } from './policy';
 export { SilotedExpertPolicy } from './siloted-expert-policy';
+export { GeneralistPolicy } from './generalist-policy';
 export { PolicyRegistry, type PolicyType } from './policy-registry';
 export { UnknownPolicyError } from './unknown-policy-error';

--- a/src/simulation/domain/policy/policy-registry.spec.ts
+++ b/src/simulation/domain/policy/policy-registry.spec.ts
@@ -60,3 +60,15 @@ describe('PolicyRegistry', () => {
     });
   });
 });
+
+describe('PolicyRegistry with the generalist policy', () => {
+  it('returns the generalist policy', () => {
+    expect(PolicyRegistry.get('generalist').id).toBe('generalist');
+  });
+
+  it('lists both policies for the selection UI', () => {
+    const ids = PolicyRegistry.list().map((policy) => policy.id);
+
+    expect(ids).toEqual(['siloted-expert', 'generalist']);
+  });
+});

--- a/src/simulation/domain/policy/policy-registry.ts
+++ b/src/simulation/domain/policy/policy-registry.ts
@@ -1,9 +1,11 @@
 import type { Policy } from './policy';
 import { SilotedExpertPolicy } from './siloted-expert-policy';
+import { GeneralistPolicy } from './generalist-policy';
 import { UnknownPolicyError } from './unknown-policy-error';
 
 const POLICIES = {
   'siloted-expert': SilotedExpertPolicy,
+  generalist: GeneralistPolicy,
 } as const satisfies Record<string, Policy>;
 
 export type PolicyType = keyof typeof POLICIES;

--- a/src/simulation/domain/policy/policy.ts
+++ b/src/simulation/domain/policy/policy.ts
@@ -1,5 +1,7 @@
 import type { Card } from '../card/card';
 import type { Worker } from '../worker/worker';
+import type { WorkerType } from '../worker/worker-type';
+import type { ColumnColor, OutputRange } from '../worker/worker-output';
 
 export interface Policy {
   readonly id: string;
@@ -7,4 +9,6 @@ export interface Policy {
   readonly description: string;
 
   assignWorkers(cards: readonly Card[], workers: readonly Worker[]): Card[];
+
+  outputRangeFor(workerType: WorkerType, columnColor: ColumnColor): OutputRange;
 }

--- a/src/simulation/domain/policy/siloted-expert-policy.spec.ts
+++ b/src/simulation/domain/policy/siloted-expert-policy.spec.ts
@@ -135,3 +135,13 @@ describe('SilotedExpertPolicy', () => {
     });
   });
 });
+
+describe('SilotedExpertPolicy output range', () => {
+  it('rewards a worker matching the column colour', () => {
+    expect(SilotedExpertPolicy.outputRangeFor('red', 'red')).toEqual({ min: 3, max: 6 });
+  });
+
+  it('gives no bonus to a worker outside their colour', () => {
+    expect(SilotedExpertPolicy.outputRangeFor('red', 'green')).toEqual({ min: 0, max: 3 });
+  });
+});

--- a/src/simulation/domain/policy/siloted-expert-policy.ts
+++ b/src/simulation/domain/policy/siloted-expert-policy.ts
@@ -1,8 +1,13 @@
 import type { Card } from '../card/card';
-import { MAX_ASSIGNED_WORKERS } from '../card/card';
 import type { Worker } from '../worker/worker';
 import type { WorkerType } from '../worker/worker-type';
+import {
+  WorkerOutputCalculator,
+  type ColumnColor,
+  type OutputRange,
+} from '../worker/worker-output';
 import type { Policy } from './policy';
+import { assignWorkersToCards } from './worker-sharing';
 
 function byAgeDescending(first: Card, second: Card): number {
   return second.age - first.age;
@@ -12,80 +17,6 @@ function cardsInStage(cards: readonly Card[], stage: Card['stage']): Card[] {
   return cards.filter((card) => card.stage === stage).sort(byAgeDescending);
 }
 
-function shareWorkersRoundRobin(
-  workersToAssign: readonly Worker[],
-  cardCount: number
-): Worker[][] {
-  const assignmentsPerCard: Worker[][] = Array.from({ length: cardCount }, () => []);
-
-  let workerIndex = 0;
-  let cardIndex = 0;
-
-  while (workerIndex < workersToAssign.length && cardIndex < cardCount) {
-    assignmentsPerCard[cardIndex].push(workersToAssign[workerIndex]);
-    workerIndex++;
-    cardIndex++;
-  }
-
-  cardIndex = 0;
-
-  while (workerIndex < workersToAssign.length) {
-    if (assignmentsPerCard[cardIndex].length < MAX_ASSIGNED_WORKERS) {
-      assignmentsPerCard[cardIndex].push(workersToAssign[workerIndex]);
-      workerIndex++;
-    }
-
-    cardIndex++;
-
-    if (cardIndex >= cardCount) {
-      const anyCardHasRoom = assignmentsPerCard.some(
-        (assignments) => assignments.length < MAX_ASSIGNED_WORKERS
-      );
-
-      if (!anyCardHasRoom) {
-        break;
-      }
-
-      cardIndex = 0;
-    }
-  }
-
-  return assignmentsPerCard;
-}
-
-function assignWorkersToCards(
-  workersToAssign: readonly Worker[],
-  cardsToAssign: readonly Card[],
-  allCards: Card[]
-): Card[] {
-  if (workersToAssign.length === 0 || cardsToAssign.length === 0) {
-    return allCards;
-  }
-
-  const assignmentsPerCard = shareWorkersRoundRobin(
-    workersToAssign,
-    cardsToAssign.length
-  );
-
-  const assignmentsByCardId = new Map(
-    cardsToAssign.map((card, index) => [card.id, assignmentsPerCard[index]])
-  );
-
-  return allCards.map((card) => {
-    const assignments = assignmentsByCardId.get(card.id);
-    if (assignments === undefined || assignments.length === 0) {
-      return card;
-    }
-
-    return {
-      ...card,
-      assignedWorkers: [
-        ...card.assignedWorkers,
-        ...assignments.map((worker) => ({ id: worker.id, type: worker.type })),
-      ],
-    };
-  });
-}
 
 const DESCRIPTION =
   'Workers always work on cards in their own active color (producing 3-6 work items). ' +
@@ -124,5 +55,9 @@ export const SilotedExpertPolicy: Policy = {
         ),
       unassignedCards
     );
+  },
+
+  outputRangeFor(workerType: WorkerType, columnColor: ColumnColor): OutputRange {
+    return WorkerOutputCalculator.getOutputRange(workerType, columnColor);
   },
 };

--- a/src/simulation/domain/policy/siloted-expert-policy.ts
+++ b/src/simulation/domain/policy/siloted-expert-policy.ts
@@ -7,7 +7,7 @@ import {
   type OutputRange,
 } from '../worker/worker-output';
 import type { Policy } from './policy';
-import { assignWorkersToCards } from './worker-sharing';
+import { assignWorkersToCards, withoutAssignments } from './worker-sharing';
 
 function byAgeDescending(first: Card, second: Card): number {
   return second.age - first.age;
@@ -16,7 +16,6 @@ function byAgeDescending(first: Card, second: Card): number {
 function cardsInStage(cards: readonly Card[], stage: Card['stage']): Card[] {
   return cards.filter((card) => card.stage === stage).sort(byAgeDescending);
 }
-
 
 const DESCRIPTION =
   'Workers always work on cards in their own active color (producing 3-6 work items). ' +
@@ -40,11 +39,7 @@ export const SilotedExpertPolicy: Policy = {
   description: DESCRIPTION,
 
   assignWorkers(cards: readonly Card[], workers: readonly Worker[]): Card[] {
-    const noWorkers: Card['assignedWorkers'] = [];
-    const unassignedCards = cards.map((card) => ({
-      ...card,
-      assignedWorkers: noWorkers,
-    }));
+    const unassignedCards = withoutAssignments(cards);
 
     return LANES.reduce(
       (assignedCards, lane) =>

--- a/src/simulation/domain/policy/worker-sharing.ts
+++ b/src/simulation/domain/policy/worker-sharing.ts
@@ -76,3 +76,8 @@ export function assignWorkersToCards(
     };
   });
 }
+
+export function withoutAssignments(cards: readonly Card[]): Card[] {
+  const noWorkers: Card['assignedWorkers'] = [];
+  return cards.map((card) => ({ ...card, assignedWorkers: noWorkers }));
+}

--- a/src/simulation/domain/policy/worker-sharing.ts
+++ b/src/simulation/domain/policy/worker-sharing.ts
@@ -1,0 +1,78 @@
+import type { Card } from '../card/card';
+import { MAX_ASSIGNED_WORKERS } from '../card/card';
+import type { Worker } from '../worker/worker';
+
+export function shareWorkersRoundRobin(
+  workersToAssign: readonly Worker[],
+  cardCount: number
+): Worker[][] {
+  const assignmentsPerCard: Worker[][] = Array.from({ length: cardCount }, () => []);
+
+  let workerIndex = 0;
+  let cardIndex = 0;
+
+  while (workerIndex < workersToAssign.length && cardIndex < cardCount) {
+    assignmentsPerCard[cardIndex].push(workersToAssign[workerIndex]);
+    workerIndex++;
+    cardIndex++;
+  }
+
+  cardIndex = 0;
+
+  while (workerIndex < workersToAssign.length) {
+    if (assignmentsPerCard[cardIndex].length < MAX_ASSIGNED_WORKERS) {
+      assignmentsPerCard[cardIndex].push(workersToAssign[workerIndex]);
+      workerIndex++;
+    }
+
+    cardIndex++;
+
+    if (cardIndex >= cardCount) {
+      const anyCardHasRoom = assignmentsPerCard.some(
+        (assignments) => assignments.length < MAX_ASSIGNED_WORKERS
+      );
+
+      if (!anyCardHasRoom) {
+        break;
+      }
+
+      cardIndex = 0;
+    }
+  }
+
+  return assignmentsPerCard;
+}
+
+export function assignWorkersToCards(
+  workersToAssign: readonly Worker[],
+  cardsToAssign: readonly Card[],
+  allCards: Card[]
+): Card[] {
+  if (workersToAssign.length === 0 || cardsToAssign.length === 0) {
+    return allCards;
+  }
+
+  const assignmentsPerCard = shareWorkersRoundRobin(
+    workersToAssign,
+    cardsToAssign.length
+  );
+
+  const assignmentsByCardId = new Map(
+    cardsToAssign.map((card, index) => [card.id, assignmentsPerCard[index]])
+  );
+
+  return allCards.map((card) => {
+    const assignments = assignmentsByCardId.get(card.id);
+    if (assignments === undefined || assignments.length === 0) {
+      return card;
+    }
+
+    return {
+      ...card,
+      assignedWorkers: [
+        ...card.assignedWorkers,
+        ...assignments.map((worker) => ({ id: worker.id, type: worker.type })),
+      ],
+    };
+  });
+}

--- a/src/simulation/domain/worker/worker-output.ts
+++ b/src/simulation/domain/worker/worker-output.ts
@@ -9,8 +9,8 @@ export interface OutputRange {
   readonly max: number;
 }
 
-const SPECIALIZED_RANGE: OutputRange = { min: 3, max: 6 };
-const NON_SPECIALIZED_RANGE: OutputRange = { min: 0, max: 3 };
+export const SPECIALIZED_RANGE: OutputRange = { min: 3, max: 6 };
+export const NON_SPECIALIZED_RANGE: OutputRange = { min: 0, max: 3 };
 
 export class WorkerOutputCalculator {
   static isSpecialized(workerType: WorkerType, columnColor: ColumnColor): boolean {
@@ -28,7 +28,18 @@ export class WorkerOutputCalculator {
     columnColor: ColumnColor,
     random: RandomFn = Math.random
   ): number {
-    const range = this.getOutputRange(workerType, columnColor);
+    return this.calculateInRange(this.getOutputRange(workerType, columnColor), random);
+  }
+
+  static calculateInRange(range: OutputRange, random: RandomFn = Math.random): number {
     return Math.floor(random() * (range.max - range.min + 1)) + range.min;
   }
 }
+
+export type OutputRangeFor = (
+  workerType: WorkerType,
+  columnColor: ColumnColor
+) => OutputRange;
+
+export const standardOutputRange: OutputRangeFor = (workerType, columnColor) =>
+  WorkerOutputCalculator.getOutputRange(workerType, columnColor);


### PR DESCRIPTION
Closes #104

## Deliverable

Une politique Generalist affecte n'importe quel worker à n'importe quelle carte active, sans bonus de spécialisation.

Closes #104

## Découverte de conception

Le critère « production toujours 0-3, quelle que soit la correspondance worker/étape » était **inatteignable** avec l'interface issue de #103.

D1.0 n'avait extrait que l'axe *affectation*. Or `applyWorkerOutputToCard` appelait `WorkerOutputCalculator.calculate(worker.type, columnColor)`, qui applique inconditionnellement le bonus 3-6 dès que les couleurs correspondent : un worker rouge sur une carte rouge aurait produit 3-6 même en mode Generalist.

`Policy` porte donc désormais `outputRangeFor`, le second axe variable — déjà présent au §7 du PRD sous le nom `outputMode`, et qui resservira à D4.1. Le pipeline le consulte au lieu d'appliquer le bonus en dur.

`advance-day.ts` (mode manuel, hors politiques) garde le calcul standard via un paramètre par défaut : aucun impact.

## Comportement de la politique

| Règle | Choix |
|---|---|
| Affectation | N'importe quel worker sur n'importe quelle carte active |
| Priorité | Âge décroissant, puis proximité de complétion, puis id |
| Production | 0-3 systématiquement |
| Cartes bloquées | Écartées |
| Plafond | 3 workers par carte, partagé avec siloted-expert |

Deux points méritent l'attention du relecteur :

- **Les départages sont totaux et déterministes** (âge → travail restant → id). Un tri partiel rendrait les comparaisons du M2 non reproductibles à seed égale, ce qui casserait D2.2.
- **Les cartes bloquées sont écartées** de l'affectation : un worker placé dessus serait perdu, `isStageComplete` retournant `false` pour une carte bloquée. C'est un cas limite explicite du ticket.

## Comportement existant préservé

`src/__golden-master__/policy-execution.golden.spec.ts` et son snapshot **ne sont pas modifiés** et restent verts. Le partage round-robin extrait dans `worker-sharing.ts` est un déplacement verbatim.

## Vérification

```bash
npm run lint     # 0 erreur, 0 warning
npm run build    # tsc -b + vite build OK
npm run test:run # 1397 tests, +23
```

Note : la politique n'est pas encore sélectionnable dans l'interface — c'est D1.5 (#108).