### PR TITLE
feat(domain): add Bottleneck-First policy concentrating workers on the constraint (M1-D1.2)

### DIFF
--- a/src/simulation/domain/policy/bottleneck-first-policy.spec.ts
+++ b/src/simulation/domain/policy/bottleneck-first-policy.spec.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import { BottleneckFirstPolicy } from './bottleneck-first-policy';
+import {
+  createTestCardWithId,
+  createValidCardId,
+} from '../card/card-test-fixtures';
+import { Worker } from '../worker/worker';
+import type { Card } from '../card/card';
+
+function assignedIdsOf(cards: readonly Card[], cardId: string): string[] {
+  const id = createValidCardId(cardId);
+  const card = cards.find((candidate) => candidate.id === id);
+  if (!card) throw new Error(`Card ${cardId} not found`);
+  return card.assignedWorkers.map((worker) => worker.id);
+}
+
+function threeWorkers(): Worker[] {
+  return [
+    Worker.create('bob', 'red'),
+    Worker.create('amy', 'blue'),
+    Worker.create('joe', 'green'),
+  ];
+}
+
+describe('BottleneckFirstPolicy', () => {
+  describe('finding the constraint', () => {
+    it('concentrates workers on the stage holding the most cards', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'red-active' }),
+        createTestCardWithId('B', { stage: 'blue-active' }),
+        createTestCardWithId('C', { stage: 'blue-active' }),
+      ];
+
+      const result = BottleneckFirstPolicy.assignWorkers(cards, threeWorkers());
+
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+      expect(assignedIdsOf(result, 'B').length + assignedIdsOf(result, 'C').length).toBe(3);
+    });
+
+    it('treats the only populated stage as the constraint', () => {
+      const cards = [createTestCardWithId('A', { stage: 'green' })];
+
+      const result = BottleneckFirstPolicy.assignWorkers(cards, [
+        Worker.create('bob', 'red'),
+      ]);
+
+      expect(assignedIdsOf(result, 'A')).toEqual(['bob']);
+    });
+
+    it('breaks a card-count tie by the older average age', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'red-active', age: 1 }),
+        createTestCardWithId('B', { stage: 'green', age: 9 }),
+      ];
+
+      const result = BottleneckFirstPolicy.assignWorkers(cards, [
+        Worker.create('bob', 'red'),
+      ]);
+
+      expect(assignedIdsOf(result, 'B')).toEqual(['bob']);
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+
+    it('breaks a full tie by pipeline order so runs stay reproducible', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'blue-active', age: 4 }),
+        createTestCardWithId('B', { stage: 'red-active', age: 4 }),
+      ];
+
+      const result = BottleneckFirstPolicy.assignWorkers(cards, [
+        Worker.create('bob', 'red'),
+      ]);
+
+      expect(assignedIdsOf(result, 'B')).toEqual(['bob']);
+    });
+  });
+
+  describe('spilling past a saturated constraint', () => {
+    it('sends surplus workers downstream rather than leaving them idle', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'red-active' }),
+        createTestCardWithId('B', { stage: 'green' }),
+      ];
+      const workers = [
+        Worker.create('w1', 'red'),
+        Worker.create('w2', 'red'),
+        Worker.create('w3', 'red'),
+        Worker.create('w4', 'red'),
+      ];
+
+      const result = BottleneckFirstPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual(['w1', 'w2', 'w3']);
+      expect(assignedIdsOf(result, 'B')).toEqual(['w4']);
+    });
+
+    it('fills the constraint before serving any other stage', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'blue-active' }),
+        createTestCardWithId('B', { stage: 'blue-active' }),
+        createTestCardWithId('C', { stage: 'red-active' }),
+      ];
+      const workers = [Worker.create('w1', 'red'), Worker.create('w2', 'red')];
+
+      const result = BottleneckFirstPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'C')).toEqual([]);
+    });
+  });
+
+  describe('ignoring cards that cannot progress', () => {
+    it('assigns no worker to a blocked card', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'red-active', isBlocked: true }),
+      ];
+
+      const result = BottleneckFirstPolicy.assignWorkers(cards, [
+        Worker.create('bob', 'red'),
+      ]);
+
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+
+    it('does not count blocked cards when locating the constraint', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'red-active', isBlocked: true }),
+        createTestCardWithId('B', { stage: 'red-active', isBlocked: true }),
+        createTestCardWithId('C', { stage: 'green' }),
+      ];
+
+      const result = BottleneckFirstPolicy.assignWorkers(cards, [
+        Worker.create('bob', 'red'),
+      ]);
+
+      expect(assignedIdsOf(result, 'C')).toEqual(['bob']);
+    });
+
+    it('ignores stages that are not active', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'red-finished' }),
+        createTestCardWithId('B', { stage: 'options' }),
+      ];
+
+      const result = BottleneckFirstPolicy.assignWorkers(cards, [
+        Worker.create('bob', 'red'),
+      ]);
+
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+      expect(assignedIdsOf(result, 'B')).toEqual([]);
+    });
+  });
+
+  describe('handling empty inputs', () => {
+    it('leaves every worker unassigned when no active card exists', () => {
+      const cards = [createTestCardWithId('A', { stage: 'options' })];
+
+      const result = BottleneckFirstPolicy.assignWorkers(cards, threeWorkers());
+
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+
+    it('returns an empty board untouched', () => {
+      const result = BottleneckFirstPolicy.assignWorkers([], threeWorkers());
+
+      expect(result).toEqual([]);
+    });
+
+    it('clears previous assignments when no worker is available', () => {
+      const cards = [
+        createTestCardWithId('A', {
+          stage: 'red-active',
+          assignedWorkers: [{ id: 'stale', type: 'red' }],
+        }),
+      ];
+
+      const result = BottleneckFirstPolicy.assignWorkers(cards, []);
+
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+  });
+
+  describe('producing with the standard ranges', () => {
+    it('keeps the specialisation bonus for a matching worker', () => {
+      expect(BottleneckFirstPolicy.outputRangeFor('red', 'red')).toEqual({
+        min: 3,
+        max: 6,
+      });
+    });
+
+    it('gives no bonus outside the worker colour', () => {
+      expect(BottleneckFirstPolicy.outputRangeFor('red', 'green')).toEqual({
+        min: 0,
+        max: 3,
+      });
+    });
+  });
+
+  describe('describing itself', () => {
+    it('is registered as bottleneck-first', () => {
+      expect(BottleneckFirstPolicy.id).toBe('bottleneck-first');
+    });
+  });
+});

--- a/src/simulation/domain/policy/bottleneck-first-policy.ts
+++ b/src/simulation/domain/policy/bottleneck-first-policy.ts
@@ -1,0 +1,84 @@
+import type { Card } from '../card/card';
+import type { Worker } from '../worker/worker';
+import type { WorkerType } from '../worker/worker-type';
+import {
+  WorkerOutputCalculator,
+  type ColumnColor,
+  type OutputRange,
+} from '../worker/worker-output';
+import type { Policy } from './policy';
+import { fillCardsInOrder, withoutAssignments } from './worker-sharing';
+
+const DESCRIPTION =
+  'All workers pile onto the constraint: the active stage holding the most cards, ' +
+  'oldest on average when stages are tied. Surplus workers spill downstream.';
+
+const ACTIVE_STAGES_IN_PIPELINE_ORDER: readonly Card['stage'][] = [
+  'red-active',
+  'blue-active',
+  'green',
+];
+
+function isWorkable(card: Card, stage: Card['stage']): boolean {
+  return card.stage === stage && !card.isBlocked;
+}
+
+function averageAgeOf(cards: readonly Card[]): number {
+  if (cards.length === 0) {
+    return 0;
+  }
+  return cards.reduce((total, card) => total + card.age, 0) / cards.length;
+}
+
+function byAgeDescending(first: Card, second: Card): number {
+  return second.age - first.age;
+}
+
+interface StageQueue {
+  readonly stage: Card['stage'];
+  readonly cards: readonly Card[];
+}
+
+function isMoreConstrainedThan(candidate: StageQueue, incumbent: StageQueue): boolean {
+  if (candidate.cards.length !== incumbent.cards.length) {
+    return candidate.cards.length > incumbent.cards.length;
+  }
+  return averageAgeOf(candidate.cards) > averageAgeOf(incumbent.cards);
+}
+
+function stageQueuesConstraintFirst(cards: readonly Card[]): StageQueue[] {
+  const queues = ACTIVE_STAGES_IN_PIPELINE_ORDER.map((stage) => ({
+    stage,
+    cards: cards.filter((card) => isWorkable(card, stage)).sort(byAgeDescending),
+  })).filter((queue) => queue.cards.length > 0);
+
+  if (queues.length === 0) {
+    return [];
+  }
+
+  const constraint = queues.reduce((incumbent, candidate) =>
+    isMoreConstrainedThan(candidate, incumbent) ? candidate : incumbent
+  );
+
+  return [constraint, ...queues.filter((queue) => queue.stage !== constraint.stage)];
+}
+
+export const BottleneckFirstPolicy: Policy = {
+  id: 'bottleneck-first',
+  name: 'Bottleneck First',
+  description: DESCRIPTION,
+
+  assignWorkers(cards: readonly Card[], workers: readonly Worker[]): Card[] {
+    const unassignedCards = withoutAssignments(cards);
+
+    const cardsConstraintFirst = stageQueuesConstraintFirst(unassignedCards).flatMap(
+      (queue) => queue.cards
+    );
+
+    return fillCardsInOrder(workers, cardsConstraintFirst, unassignedCards);
+  },
+
+  outputRangeFor(workerType: WorkerType, columnColor: ColumnColor): OutputRange {
+    return WorkerOutputCalculator.getOutputRange(workerType, columnColor);
+  },
+};

--- a/src/simulation/domain/policy/index.ts
+++ b/src/simulation/domain/policy/index.ts
@@ -1,5 +1,6 @@
 export type { Policy } from './policy';
 export { SilotedExpertPolicy } from './siloted-expert-policy';
 export { GeneralistPolicy } from './generalist-policy';
+export { BottleneckFirstPolicy } from './bottleneck-first-policy';
 export { PolicyRegistry, type PolicyType } from './policy-registry';
 export { UnknownPolicyError } from './unknown-policy-error';

--- a/src/simulation/domain/policy/policy-registry.spec.ts
+++ b/src/simulation/domain/policy/policy-registry.spec.ts
@@ -69,6 +69,6 @@ describe('PolicyRegistry with the generalist policy', () => {
   it('lists both policies for the selection UI', () => {
     const ids = PolicyRegistry.list().map((policy) => policy.id);
 
-    expect(ids).toEqual(['siloted-expert', 'generalist']);
+    expect(ids).toEqual(['siloted-expert', 'generalist', 'bottleneck-first']);
   });
 });

--- a/src/simulation/domain/policy/policy-registry.ts
+++ b/src/simulation/domain/policy/policy-registry.ts
@@ -1,11 +1,13 @@
 import type { Policy } from './policy';
 import { SilotedExpertPolicy } from './siloted-expert-policy';
 import { GeneralistPolicy } from './generalist-policy';
+import { BottleneckFirstPolicy } from './bottleneck-first-policy';
 import { UnknownPolicyError } from './unknown-policy-error';
 
 const POLICIES = {
   'siloted-expert': SilotedExpertPolicy,
   generalist: GeneralistPolicy,
+  'bottleneck-first': BottleneckFirstPolicy,
 } as const satisfies Record<string, Policy>;
 
 export type PolicyType = keyof typeof POLICIES;

--- a/src/simulation/domain/policy/worker-sharing.ts
+++ b/src/simulation/domain/policy/worker-sharing.ts
@@ -57,8 +57,16 @@ export function assignWorkersToCards(
     cardsToAssign.length
   );
 
+  return applyAssignments(cardsToAssign, assignmentsPerCard, allCards);
+}
+
+function applyAssignments(
+  assignedCards: readonly Card[],
+  assignmentsPerCard: readonly Worker[][],
+  allCards: Card[]
+): Card[] {
   const assignmentsByCardId = new Map(
-    cardsToAssign.map((card, index) => [card.id, assignmentsPerCard[index]])
+    assignedCards.map((card, index) => [card.id, assignmentsPerCard[index]])
   );
 
   return allCards.map((card) => {
@@ -80,4 +88,34 @@ export function assignWorkersToCards(
 export function withoutAssignments(cards: readonly Card[]): Card[] {
   const noWorkers: Card['assignedWorkers'] = [];
   return cards.map((card) => ({ ...card, assignedWorkers: noWorkers }));
+}
+
+export function fillCardsInOrder(
+  workersToAssign: readonly Worker[],
+  cardsInPriorityOrder: readonly Card[],
+  allCards: Card[]
+): Card[] {
+  if (workersToAssign.length === 0 || cardsInPriorityOrder.length === 0) {
+    return allCards;
+  }
+
+  const assignmentsPerCard: Worker[][] = cardsInPriorityOrder.map(() => []);
+
+  let cardIndex = 0;
+  for (const worker of workersToAssign) {
+    while (
+      cardIndex < cardsInPriorityOrder.length &&
+      assignmentsPerCard[cardIndex].length >= MAX_ASSIGNED_WORKERS
+    ) {
+      cardIndex++;
+    }
+
+    if (cardIndex >= cardsInPriorityOrder.length) {
+      break;
+    }
+
+    assignmentsPerCard[cardIndex].push(worker);
+  }
+
+  return applyAssignments(cardsInPriorityOrder, assignmentsPerCard, allCards);
 }


### PR DESCRIPTION
Closes #105

## Deliverable

Une politique Bottleneck-First concentre les workers disponibles sur l'étape identifiée comme goulot d'étranglement.

Closes #105

## Le point technique

Concentrer les workers sur le goulot est **incompatible avec le partage round-robin** utilisé par siloted-expert et generalist, qui répartit équitablement une carte à la fois.

D'où `fillCardsInOrder` dans `worker-sharing` : les cartes sont remplies jusqu'au plafond de 3 dans l'ordre de priorité avant qu'une autre étape ne soit servie. Les deux stratégies de partage coexistent maintenant, chaque politique choisissant la sienne.

L'extraction d'`applyAssignments`, commune aux deux, est un déplacement verbatim — le comportement de `assignWorkersToCards` est inchangé.

## Identification du goulot

Nombre de cartes → âge moyen le plus élevé → ordre du pipeline (rouge, bleu, vert).

Le départage est **total et déterministe**, comme pour Generalist : un ordre partiel rendrait les comparaisons du M2 non reproductibles à seed égale.

Les **cartes bloquées ne comptent pas** dans le calcul et ne reçoivent aucun worker — une colonne saturée de cartes bloquées n'est pas une contrainte qu'on peut soulager en y envoyant du monde.

## Une limite assumée, à valider

Le ticket listait aussi « le pull de nouvelles cartes est déclenché pour maintenir le goulot alimenté ». **Ce n'est pas implémenté comme un comportement propre à cette politique.**

Le pull reste celui du pipeline partagé (`moveOptionsToRedActive`, `moveFinishedToNextActivity`, sous contrainte `WipLimitEnforcer`), qui s'exécute pour toutes les politiques avant `assignWorkers`. Le goulot n'est donc jamais affamé par omission, mais rien dans `BottleneckFirstPolicy` n'influence le pull.

Ajouter un troisième axe `pullCards` à `Policy` serait spéculatif : c'est le `pullTrigger` configurable de D4.1, et aucune politique du M1 n'en a besoin. Si l'intention du critère était un pull réellement piloté par le goulot, c'est un ajout à faire — à trancher au merge.

## Note d'architecture

Les guidelines du ticket suggéraient de réutiliser `countCardsInStage` depuis `card-stage-helpers.ts`. Je ne l'ai pas fait : ce module est dans `application`, qui se situe **au-dessus** de `domain` dans le sens des dépendances. L'importer serait une violation de couche. La politique définit ses propres prédicats, exactement comme `generalist-policy.ts` juste à côté.

## Vérification

```bash
npm run lint     # 0 erreur, 0 warning
npm run build    # tsc -b + vite build OK
npm run test:run # 1412 tests, +15
```

Golden master non modifié et vert : siloted-expert et generalist sont intacts.