### PR TITLE
feat(domain): add Throughput-Maximizer policy prioritising work closest to Done (M1-D1.3)

### DIFF
--- a/src/simulation/application/run-policy.spec.ts
+++ b/src/simulation/application/run-policy.spec.ts
@@ -359,6 +359,7 @@ describe('RunPolicyUseCase policy delegation', () => {
         return [...cards];
       },
       outputRangeFor: () => ({ min: 0, max: 3 }),
+      allowsPullFromOptions: () => true,
     };
 
     runPolicyDay({
@@ -384,6 +385,7 @@ describe('RunPolicyUseCase policy delegation', () => {
           assignedWorkers: [{ id: 'ghost', type: 'red' as const }],
         })),
       outputRangeFor: () => ({ min: 0, max: 3 }),
+      allowsPullFromOptions: () => true,
     };
 
     const result = runPolicyDay({
@@ -482,5 +484,56 @@ describe('RunPolicyUseCase output range delegation', () => {
     });
 
     expect(result.cards[0].workItems.blue.completed).toBe(3);
+  });
+});
+
+describe('RunPolicyUseCase pull gating', () => {
+  const noOutput = (): number => 0;
+
+  it('holds a card in options while the pipeline is busy', () => {
+    const result = runPolicyDay({
+      policyType: 'throughput-maximizer',
+      cards: [
+        createTestCard({ id: createValidCardId('A'), stage: 'options' }),
+        createTestCard({ id: createValidCardId('B'), stage: 'green' }),
+      ],
+      workers: [],
+      currentDay: 0,
+      wipLimits: WipLimits.empty(),
+      random: noOutput,
+    });
+
+    const optionsCard = result.cards.find((card) => String(card.id) === 'A');
+    expect(optionsCard?.stage).toBe('options');
+  });
+
+  it('pulls a card once the pipeline is clear', () => {
+    const result = runPolicyDay({
+      policyType: 'throughput-maximizer',
+      cards: [createTestCard({ id: createValidCardId('A'), stage: 'options' })],
+      workers: [],
+      currentDay: 0,
+      wipLimits: WipLimits.empty(),
+      random: noOutput,
+    });
+
+    expect(result.cards[0].stage).toBe('red-active');
+  });
+
+  it('still pulls under policies that do not gate the pull', () => {
+    const result = runPolicyDay({
+      policyType: 'siloted-expert',
+      cards: [
+        createTestCard({ id: createValidCardId('A'), stage: 'options' }),
+        createTestCard({ id: createValidCardId('B'), stage: 'green' }),
+      ],
+      workers: [],
+      currentDay: 0,
+      wipLimits: WipLimits.empty(),
+      random: noOutput,
+    });
+
+    const optionsCard = result.cards.find((card) => String(card.id) === 'A');
+    expect(optionsCard?.stage).toBe('red-active');
   });
 });

--- a/src/simulation/application/run-policy.spec.ts
+++ b/src/simulation/application/run-policy.spec.ts
@@ -537,3 +537,29 @@ describe('RunPolicyUseCase pull gating', () => {
     expect(optionsCard?.stage).toBe('red-active');
   });
 });
+
+describe('RunPolicyUseCase pull gating combined with WIP limits', () => {
+  const noOutput = (): number => 0;
+
+  it('still honours a binding WIP limit when the policy allows the pull', () => {
+    const wipLimits = WipLimits.withColumnLimit(WipLimits.empty(), 'redActive', {
+      min: 0,
+      max: 1,
+    });
+
+    const result = runPolicyDay({
+      policyType: 'throughput-maximizer',
+      cards: [
+        createTestCard({ id: createValidCardId('A'), stage: 'options' }),
+        createTestCard({ id: createValidCardId('B'), stage: 'options' }),
+      ],
+      workers: [],
+      currentDay: 0,
+      wipLimits,
+      random: noOutput,
+    });
+
+    const inRedActive = result.cards.filter((card) => card.stage === 'red-active');
+    expect(inRedActive).toHaveLength(1);
+  });
+});

--- a/src/simulation/application/run-policy.ts
+++ b/src/simulation/application/run-policy.ts
@@ -258,11 +258,9 @@ export function runPolicyDay(input: RunPolicyInput): RunPolicyResult {
   const policy = resolvePolicy(input);
   const newDay = currentDay + 1;
 
-  const cardsAfterOptionsMove = moveOptionsToRedActive(
-    [...cards],
-    currentDay,
-    wipLimits
-  );
+  const cardsAfterOptionsMove = policy.allowsPullFromOptions(cards)
+    ? moveOptionsToRedActive([...cards], currentDay, wipLimits)
+    : [...cards];
 
   const cardsAfterFinishedMove = moveFinishedToNextActivity(
     cardsAfterOptionsMove,

--- a/src/simulation/domain/policy/active-card.ts
+++ b/src/simulation/domain/policy/active-card.ts
@@ -1,0 +1,33 @@
+import type { Card } from '../card/card';
+import type { ColumnColor } from '../worker/worker-output';
+
+export type ActiveStage = 'red-active' | 'blue-active' | 'green';
+
+export const ACTIVE_STAGES_IN_PIPELINE_ORDER: readonly ActiveStage[] = [
+  'red-active',
+  'blue-active',
+  'green',
+];
+
+export interface ActiveCard extends Card {
+  readonly stage: ActiveStage;
+}
+
+function isActiveStage(stage: Card['stage']): stage is ActiveStage {
+  return stage === 'red-active' || stage === 'blue-active' || stage === 'green';
+}
+
+export function isWorkableCard(card: Card): card is ActiveCard {
+  return isActiveStage(card.stage) && !card.isBlocked;
+}
+
+export function colorOfActiveStage(stage: ActiveStage): ColumnColor {
+  if (stage === 'red-active') return 'red';
+  if (stage === 'blue-active') return 'blue';
+  return 'green';
+}
+
+export function remainingWorkOn(card: ActiveCard): number {
+  const progress = card.workItems[colorOfActiveStage(card.stage)];
+  return progress.total - progress.completed;
+}

--- a/src/simulation/domain/policy/bottleneck-first-policy.ts
+++ b/src/simulation/domain/policy/bottleneck-first-policy.ts
@@ -8,20 +8,15 @@ import {
 } from '../worker/worker-output';
 import type { Policy } from './policy';
 import { fillCardsInOrder, withoutAssignments } from './worker-sharing';
+import {
+  ACTIVE_STAGES_IN_PIPELINE_ORDER,
+  isWorkableCard,
+  type ActiveStage,
+} from './active-card';
 
 const DESCRIPTION =
   'All workers pile onto the constraint: the active stage holding the most cards, ' +
   'oldest on average when stages are tied. Surplus workers spill downstream.';
-
-const ACTIVE_STAGES_IN_PIPELINE_ORDER: readonly Card['stage'][] = [
-  'red-active',
-  'blue-active',
-  'green',
-];
-
-function isWorkable(card: Card, stage: Card['stage']): boolean {
-  return card.stage === stage && !card.isBlocked;
-}
 
 function averageAgeOf(cards: readonly Card[]): number {
   if (cards.length === 0) {
@@ -35,7 +30,7 @@ function byAgeDescending(first: Card, second: Card): number {
 }
 
 interface StageQueue {
-  readonly stage: Card['stage'];
+  readonly stage: ActiveStage;
   readonly cards: readonly Card[];
 }
 
@@ -49,7 +44,7 @@ function isMoreConstrainedThan(candidate: StageQueue, incumbent: StageQueue): bo
 function stageQueuesConstraintFirst(cards: readonly Card[]): StageQueue[] {
   const queues = ACTIVE_STAGES_IN_PIPELINE_ORDER.map((stage) => ({
     stage,
-    cards: cards.filter((card) => isWorkable(card, stage)).sort(byAgeDescending),
+    cards: cards.filter(isWorkableCard).filter((card) => card.stage === stage).sort(byAgeDescending),
   })).filter((queue) => queue.cards.length > 0);
 
   if (queues.length === 0) {

--- a/src/simulation/domain/policy/bottleneck-first-policy.ts
+++ b/src/simulation/domain/policy/bottleneck-first-policy.ts
@@ -81,4 +81,8 @@ export const BottleneckFirstPolicy: Policy = {
   outputRangeFor(workerType: WorkerType, columnColor: ColumnColor): OutputRange {
     return WorkerOutputCalculator.getOutputRange(workerType, columnColor);
   },
+
+  allowsPullFromOptions(): boolean {
+    return true;
+  },
 };

--- a/src/simulation/domain/policy/generalist-policy.ts
+++ b/src/simulation/domain/policy/generalist-policy.ts
@@ -64,4 +64,8 @@ export const GeneralistPolicy: Policy = {
   outputRangeFor(): OutputRange {
     return NON_SPECIALIZED_RANGE;
   },
+
+  allowsPullFromOptions(): boolean {
+    return true;
+  },
 };

--- a/src/simulation/domain/policy/generalist-policy.ts
+++ b/src/simulation/domain/policy/generalist-policy.ts
@@ -2,38 +2,17 @@ import type { Card } from '../card/card';
 import type { Worker } from '../worker/worker';
 import {
   NON_SPECIALIZED_RANGE,
-  type ColumnColor,
   type OutputRange,
 } from '../worker/worker-output';
 import type { Policy } from './policy';
 import { assignWorkersToCards, withoutAssignments } from './worker-sharing';
+import { remainingWorkOn, isWorkableCard, type ActiveCard } from './active-card';
 
 const DESCRIPTION =
   'Workers take on any card needing work regardless of colour (producing 0-3 work items). ' +
   'The oldest cards are served first, then the ones closest to completion.';
 
-const ACTIVE_STAGES: readonly Card['stage'][] = [
-  'red-active',
-  'blue-active',
-  'green',
-];
-
-function colorOfStage(stage: Card['stage']): ColumnColor {
-  if (stage === 'red-active') return 'red';
-  if (stage === 'blue-active') return 'blue';
-  return 'green';
-}
-
-function remainingWorkOn(card: Card): number {
-  const progress = card.workItems[colorOfStage(card.stage)];
-  return progress.total - progress.completed;
-}
-
-function isAvailableForWork(card: Card): boolean {
-  return !card.isBlocked && ACTIVE_STAGES.includes(card.stage);
-}
-
-function byOldestThenClosestToCompletion(first: Card, second: Card): number {
+function byOldestThenClosestToCompletion(first: ActiveCard, second: ActiveCard): number {
   if (first.age !== second.age) {
     return second.age - first.age;
   }
@@ -55,7 +34,7 @@ export const GeneralistPolicy: Policy = {
     const unassignedCards = withoutAssignments(cards);
 
     const cardsNeedingWork = unassignedCards
-      .filter(isAvailableForWork)
+      .filter(isWorkableCard)
       .sort(byOldestThenClosestToCompletion);
 
     return assignWorkersToCards(workers, cardsNeedingWork, unassignedCards);

--- a/src/simulation/domain/policy/index.ts
+++ b/src/simulation/domain/policy/index.ts
@@ -2,5 +2,6 @@ export type { Policy } from './policy';
 export { SilotedExpertPolicy } from './siloted-expert-policy';
 export { GeneralistPolicy } from './generalist-policy';
 export { BottleneckFirstPolicy } from './bottleneck-first-policy';
+export { ThroughputMaximizerPolicy } from './throughput-maximizer-policy';
 export { PolicyRegistry, type PolicyType } from './policy-registry';
 export { UnknownPolicyError } from './unknown-policy-error';

--- a/src/simulation/domain/policy/policy-registry.spec.ts
+++ b/src/simulation/domain/policy/policy-registry.spec.ts
@@ -69,6 +69,11 @@ describe('PolicyRegistry with the generalist policy', () => {
   it('lists both policies for the selection UI', () => {
     const ids = PolicyRegistry.list().map((policy) => policy.id);
 
-    expect(ids).toEqual(['siloted-expert', 'generalist', 'bottleneck-first']);
+    expect(ids).toEqual([
+      'siloted-expert',
+      'generalist',
+      'bottleneck-first',
+      'throughput-maximizer',
+    ]);
   });
 });

--- a/src/simulation/domain/policy/policy-registry.ts
+++ b/src/simulation/domain/policy/policy-registry.ts
@@ -2,12 +2,14 @@ import type { Policy } from './policy';
 import { SilotedExpertPolicy } from './siloted-expert-policy';
 import { GeneralistPolicy } from './generalist-policy';
 import { BottleneckFirstPolicy } from './bottleneck-first-policy';
+import { ThroughputMaximizerPolicy } from './throughput-maximizer-policy';
 import { UnknownPolicyError } from './unknown-policy-error';
 
 const POLICIES = {
   'siloted-expert': SilotedExpertPolicy,
   generalist: GeneralistPolicy,
   'bottleneck-first': BottleneckFirstPolicy,
+  'throughput-maximizer': ThroughputMaximizerPolicy,
 } as const satisfies Record<string, Policy>;
 
 export type PolicyType = keyof typeof POLICIES;

--- a/src/simulation/domain/policy/policy.ts
+++ b/src/simulation/domain/policy/policy.ts
@@ -11,4 +11,6 @@ export interface Policy {
   assignWorkers(cards: readonly Card[], workers: readonly Worker[]): Card[];
 
   outputRangeFor(workerType: WorkerType, columnColor: ColumnColor): OutputRange;
+
+  allowsPullFromOptions(cards: readonly Card[]): boolean;
 }

--- a/src/simulation/domain/policy/siloted-expert-policy.ts
+++ b/src/simulation/domain/policy/siloted-expert-policy.ts
@@ -55,4 +55,8 @@ export const SilotedExpertPolicy: Policy = {
   outputRangeFor(workerType: WorkerType, columnColor: ColumnColor): OutputRange {
     return WorkerOutputCalculator.getOutputRange(workerType, columnColor);
   },
+
+  allowsPullFromOptions(): boolean {
+    return true;
+  },
 };

--- a/src/simulation/domain/policy/throughput-maximizer-policy.spec.ts
+++ b/src/simulation/domain/policy/throughput-maximizer-policy.spec.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest';
+import { ThroughputMaximizerPolicy } from './throughput-maximizer-policy';
+import {
+  createTestCardWithId,
+  createValidCardId,
+} from '../card/card-test-fixtures';
+import { Worker } from '../worker/worker';
+import type { Card } from '../card/card';
+import type { WorkItems } from '../card/work-items';
+
+function assignedIdsOf(cards: readonly Card[], cardId: string): string[] {
+  const id = createValidCardId(cardId);
+  const card = cards.find((candidate) => candidate.id === id);
+  if (!card) throw new Error(`Card ${cardId} not found`);
+  return card.assignedWorkers.map((worker) => worker.id);
+}
+
+function greenRemaining(remaining: number): WorkItems {
+  return {
+    red: { total: 5, completed: 5 },
+    blue: { total: 5, completed: 5 },
+    green: { total: 10, completed: 10 - remaining },
+  };
+}
+
+describe('ThroughputMaximizerPolicy', () => {
+  describe('serving the work closest to Done first', () => {
+    it('prefers a green card over a blue one', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'blue-active' }),
+        createTestCardWithId('B', { stage: 'green' }),
+      ];
+
+      const result = ThroughputMaximizerPolicy.assignWorkers(cards, [
+        Worker.create('bob', 'red'),
+      ]);
+
+      expect(assignedIdsOf(result, 'B')).toEqual(['bob']);
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+
+    it('prefers a blue card over a red one', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'red-active' }),
+        createTestCardWithId('B', { stage: 'blue-active' }),
+      ];
+
+      const result = ThroughputMaximizerPolicy.assignWorkers(cards, [
+        Worker.create('bob', 'red'),
+      ]);
+
+      expect(assignedIdsOf(result, 'B')).toEqual(['bob']);
+    });
+
+    it('ignores the age that other policies sort on', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'red-active', age: 99 }),
+        createTestCardWithId('B', { stage: 'green', age: 1 }),
+      ];
+
+      const result = ThroughputMaximizerPolicy.assignWorkers(cards, [
+        Worker.create('bob', 'red'),
+      ]);
+
+      expect(assignedIdsOf(result, 'B')).toEqual(['bob']);
+    });
+  });
+
+  describe('breaking ties within a stage', () => {
+    it('serves the card with the least work remaining', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'green', workItems: greenRemaining(9) }),
+        createTestCardWithId('B', { stage: 'green', workItems: greenRemaining(1) }),
+      ];
+
+      const result = ThroughputMaximizerPolicy.assignWorkers(cards, [
+        Worker.create('bob', 'red'),
+      ]);
+
+      expect(assignedIdsOf(result, 'B')).toEqual(['bob']);
+    });
+
+    it('falls back to card id so runs stay reproducible', () => {
+      const cards = [
+        createTestCardWithId('B', { stage: 'green', workItems: greenRemaining(4) }),
+        createTestCardWithId('A', { stage: 'green', workItems: greenRemaining(4) }),
+      ];
+
+      const result = ThroughputMaximizerPolicy.assignWorkers(cards, [
+        Worker.create('bob', 'red'),
+      ]);
+
+      expect(assignedIdsOf(result, 'A')).toEqual(['bob']);
+    });
+  });
+
+  describe('holding new work back until the pipeline clears', () => {
+    it('refuses the pull while an unblocked card is still in progress', () => {
+      const cards = [createTestCardWithId('A', { stage: 'red-active' })];
+
+      expect(ThroughputMaximizerPolicy.allowsPullFromOptions(cards)).toBe(false);
+    });
+
+    it('refuses the pull while a card waits in a finished queue', () => {
+      const cards = [createTestCardWithId('A', { stage: 'blue-finished' })];
+
+      expect(ThroughputMaximizerPolicy.allowsPullFromOptions(cards)).toBe(false);
+    });
+
+    it('allows the pull once the pipeline is empty', () => {
+      const cards = [createTestCardWithId('A', { stage: 'options' })];
+
+      expect(ThroughputMaximizerPolicy.allowsPullFromOptions(cards)).toBe(true);
+    });
+
+    it('allows the pull on a completely empty board', () => {
+      expect(ThroughputMaximizerPolicy.allowsPullFromOptions([])).toBe(true);
+    });
+
+    it('does not let a blocked card hold the pull back forever', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'green', isBlocked: true }),
+        createTestCardWithId('B', { stage: 'options' }),
+      ];
+
+      expect(ThroughputMaximizerPolicy.allowsPullFromOptions(cards)).toBe(true);
+    });
+
+    it('ignores cards already done', () => {
+      const cards = [createTestCardWithId('A', { stage: 'done' })];
+
+      expect(ThroughputMaximizerPolicy.allowsPullFromOptions(cards)).toBe(true);
+    });
+  });
+
+  describe('respecting the three-worker ceiling', () => {
+    it('stacks at most three workers before serving the next card', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'green', workItems: greenRemaining(1) }),
+        createTestCardWithId('B', { stage: 'green', workItems: greenRemaining(9) }),
+      ];
+      const workers = [
+        Worker.create('w1', 'red'),
+        Worker.create('w2', 'red'),
+        Worker.create('w3', 'red'),
+        Worker.create('w4', 'red'),
+      ];
+
+      const result = ThroughputMaximizerPolicy.assignWorkers(cards, workers);
+
+      expect(assignedIdsOf(result, 'A')).toEqual(['w1', 'w2', 'w3']);
+      expect(assignedIdsOf(result, 'B')).toEqual(['w4']);
+    });
+  });
+
+  describe('skipping cards that cannot progress', () => {
+    it('assigns no worker to a blocked card', () => {
+      const cards = [
+        createTestCardWithId('A', { stage: 'green', isBlocked: true }),
+      ];
+
+      const result = ThroughputMaximizerPolicy.assignWorkers(cards, [
+        Worker.create('bob', 'red'),
+      ]);
+
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+
+    it('ignores stages that are not active', () => {
+      const cards = [createTestCardWithId('A', { stage: 'red-finished' })];
+
+      const result = ThroughputMaximizerPolicy.assignWorkers(cards, [
+        Worker.create('bob', 'red'),
+      ]);
+
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+  });
+
+  describe('handling empty inputs', () => {
+    it('returns an empty board untouched', () => {
+      const result = ThroughputMaximizerPolicy.assignWorkers([], [
+        Worker.create('bob', 'red'),
+      ]);
+
+      expect(result).toEqual([]);
+    });
+
+    it('clears previous assignments when no worker is available', () => {
+      const cards = [
+        createTestCardWithId('A', {
+          stage: 'green',
+          assignedWorkers: [{ id: 'stale', type: 'red' }],
+        }),
+      ];
+
+      const result = ThroughputMaximizerPolicy.assignWorkers(cards, []);
+
+      expect(assignedIdsOf(result, 'A')).toEqual([]);
+    });
+  });
+
+  describe('producing with the standard ranges', () => {
+    it('keeps the specialisation bonus for a matching worker', () => {
+      expect(ThroughputMaximizerPolicy.outputRangeFor('green', 'green')).toEqual({
+        min: 3,
+        max: 6,
+      });
+    });
+  });
+
+  describe('describing itself', () => {
+    it('is registered as throughput-maximizer', () => {
+      expect(ThroughputMaximizerPolicy.id).toBe('throughput-maximizer');
+    });
+  });
+});

--- a/src/simulation/domain/policy/throughput-maximizer-policy.ts
+++ b/src/simulation/domain/policy/throughput-maximizer-policy.ts
@@ -1,0 +1,85 @@
+import type { Card } from '../card/card';
+import type { Worker } from '../worker/worker';
+import type { WorkerType } from '../worker/worker-type';
+import {
+  WorkerOutputCalculator,
+  type ColumnColor,
+  type OutputRange,
+} from '../worker/worker-output';
+import type { Policy } from './policy';
+import { fillCardsInOrder, withoutAssignments } from './worker-sharing';
+
+const DESCRIPTION =
+  'Stop starting, start finishing: workers serve the cards closest to Done first ' +
+  '(green before blue before red), and no new card leaves Options until the pipeline is clear.';
+
+const STAGES_CLOSEST_TO_DONE_FIRST: readonly Card['stage'][] = [
+  'green',
+  'blue-active',
+  'red-active',
+];
+
+const IN_PROGRESS_STAGES: readonly Card['stage'][] = [
+  'red-active',
+  'red-finished',
+  'blue-active',
+  'blue-finished',
+  'green',
+];
+
+function colorOfStage(stage: Card['stage']): ColumnColor {
+  if (stage === 'red-active') return 'red';
+  if (stage === 'blue-active') return 'blue';
+  return 'green';
+}
+
+function remainingWorkOn(card: Card): number {
+  const progress = card.workItems[colorOfStage(card.stage)];
+  return progress.total - progress.completed;
+}
+
+function byLeastWorkRemaining(first: Card, second: Card): number {
+  const remainingDifference = remainingWorkOn(first) - remainingWorkOn(second);
+  if (remainingDifference !== 0) {
+    return remainingDifference;
+  }
+  return first.id.localeCompare(second.id);
+}
+
+function isWorkable(card: Card): boolean {
+  return !card.isBlocked;
+}
+
+function cardsClosestToDoneFirst(cards: readonly Card[]): Card[] {
+  return STAGES_CLOSEST_TO_DONE_FIRST.flatMap((stage) =>
+    cards
+      .filter((card) => card.stage === stage && isWorkable(card))
+      .sort(byLeastWorkRemaining)
+  );
+}
+
+export const ThroughputMaximizerPolicy: Policy = {
+  id: 'throughput-maximizer',
+  name: 'Throughput Maximizer',
+  description: DESCRIPTION,
+
+  assignWorkers(cards: readonly Card[], workers: readonly Worker[]): Card[] {
+    const unassignedCards = withoutAssignments(cards);
+
+    return fillCardsInOrder(
+      workers,
+      cardsClosestToDoneFirst(unassignedCards),
+      unassignedCards
+    );
+  },
+
+  outputRangeFor(workerType: WorkerType, columnColor: ColumnColor): OutputRange {
+    return WorkerOutputCalculator.getOutputRange(workerType, columnColor);
+  },
+
+  allowsPullFromOptions(cards: readonly Card[]): boolean {
+    return !cards.some(
+      (card) => IN_PROGRESS_STAGES.includes(card.stage) && isWorkable(card)
+    );
+  },
+};

--- a/src/simulation/domain/policy/throughput-maximizer-policy.ts
+++ b/src/simulation/domain/policy/throughput-maximizer-policy.ts
@@ -8,12 +8,18 @@ import {
 } from '../worker/worker-output';
 import type { Policy } from './policy';
 import { fillCardsInOrder, withoutAssignments } from './worker-sharing';
+import {
+  remainingWorkOn,
+  isWorkableCard,
+  type ActiveCard,
+  type ActiveStage,
+} from './active-card';
 
 const DESCRIPTION =
   'Stop starting, start finishing: workers serve the cards closest to Done first ' +
   '(green before blue before red), and no new card leaves Options until the pipeline is clear.';
 
-const STAGES_CLOSEST_TO_DONE_FIRST: readonly Card['stage'][] = [
+const STAGES_CLOSEST_TO_DONE_FIRST: readonly ActiveStage[] = [
   'green',
   'blue-active',
   'red-active',
@@ -27,18 +33,7 @@ const IN_PROGRESS_STAGES: readonly Card['stage'][] = [
   'green',
 ];
 
-function colorOfStage(stage: Card['stage']): ColumnColor {
-  if (stage === 'red-active') return 'red';
-  if (stage === 'blue-active') return 'blue';
-  return 'green';
-}
-
-function remainingWorkOn(card: Card): number {
-  const progress = card.workItems[colorOfStage(card.stage)];
-  return progress.total - progress.completed;
-}
-
-function byLeastWorkRemaining(first: Card, second: Card): number {
+function byLeastWorkRemaining(first: ActiveCard, second: ActiveCard): number {
   const remainingDifference = remainingWorkOn(first) - remainingWorkOn(second);
   if (remainingDifference !== 0) {
     return remainingDifference;
@@ -46,15 +41,11 @@ function byLeastWorkRemaining(first: Card, second: Card): number {
   return first.id.localeCompare(second.id);
 }
 
-function isWorkable(card: Card): boolean {
-  return !card.isBlocked;
-}
-
 function cardsClosestToDoneFirst(cards: readonly Card[]): Card[] {
+  const workableCards = cards.filter(isWorkableCard);
+
   return STAGES_CLOSEST_TO_DONE_FIRST.flatMap((stage) =>
-    cards
-      .filter((card) => card.stage === stage && isWorkable(card))
-      .sort(byLeastWorkRemaining)
+    workableCards.filter((card) => card.stage === stage).sort(byLeastWorkRemaining)
   );
 }
 
@@ -79,7 +70,7 @@ export const ThroughputMaximizerPolicy: Policy = {
 
   allowsPullFromOptions(cards: readonly Card[]): boolean {
     return !cards.some(
-      (card) => IN_PROGRESS_STAGES.includes(card.stage) && isWorkable(card)
+      (card) => IN_PROGRESS_STAGES.includes(card.stage) && !card.isBlocked
     );
   },
 };


### PR DESCRIPTION
Closes #106

## Deliverable

Une politique Throughput-Maximizer priorise les cartes les plus proches de Done et retient le nouveau travail tant que le pipeline n'est pas dégagé.

Closes #106

## Un troisième axe sur `Policy`

`allowsPullFromOptions(cards): boolean` est ajouté à l'interface, et `runPolicyDay` conditionne `moveOptionsToRedActive` dessus.

Sur #105 (Bottleneck-First) j'avais **délibérément refusé** d'ajouter cet axe, en jugeant le pull piloté par la politique spéculatif. La situation est différente ici : « aucune carte ne quitte Options tant que l'aval n'est pas dégagé » est le comportement **définitoire** de cette politique — « stop starting, start finishing » n'existe pas sans lui.

L'axe est donc ajouté au moment où un livrable l'exige, pas avant. C'est le même schéma que pour les deux précédents : affectation (#103), production (#104), pull (#106).

Les trois politiques existantes retournent `true` : comportement inchangé, prouvé par le golden master et par un test dédié (`still pulls under policies that do not gate the pull`).

## Points de vigilance pour la relecture

**Pas de blocage possible.** Une carte bloquée ne compte pas comme travail en cours dans le gate. Sinon elle gèlerait le pull indéfiniment et la simulation se figerait avec des cartes coincées en Options.

**Le gate s'ajoute aux limites WIP, il ne les remplace pas.** Quand le pull est autorisé, `moveOptionsToRedActive` applique `WipLimitEnforcer` comme avant — le corps de la fonction n'est pas touché. Un test le prouve explicitement : pipeline vide (donc pull autorisé) + `redActive` max=1 → une seule des deux cartes passe.

**Départage total** (étape → travail restant → id), pour la reproductibilité du M2.

## Corrections issues de la revue

- `colorOfStage` acceptait les 7 étapes mais n'en traitait que 3, faisant retomber silencieusement `options`, `done` et les files `finished` sur `'green'`. Dormant parce que les appelants filtrent en amont, mais rien ne l'imposait. Le type `ActiveStage` et le garde `isWorkableCard` rendent désormais l'état illégal irreprésentable — le compilateur interdit d'appeler `remainingWorkOn` sur une carte non active.
- `colorOfStage` et `remainingWorkOn` étaient dupliqués entre generalist et throughput-maximizer : extraits dans `active-card.ts`, utilisé par les trois politiques.

## Vérification

```bash
npm run lint     # 0 erreur, 0 warning
npm run build    # tsc -b + vite build OK
npm run test:run # 1434 tests, +22
```

Golden master non modifié et vert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a throughput-maximizing work policy that prioritizes cards closest to completion and with the least remaining work.
  * Made the new policy available for selection alongside existing policies.
  * Added pull gating to prevent cards leaving Options when downstream work is blocked or active work limits are reached.
  * Standardized active-stage handling and remaining-work calculations across policies.

* **Bug Fixes**
  * Improved enforcement of work-in-progress limits during card movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->